### PR TITLE
pool: Remove referralCode support from Aave

### DIFF
--- a/contracts/pools/AaveTempusPool.sol
+++ b/contracts/pools/AaveTempusPool.sol
@@ -16,7 +16,6 @@ contract AaveTempusPool is TempusPool {
 
     ILendingPool internal immutable aavePool;
     bytes32 public constant override protocolName = "Aave";
-    uint16 private immutable referrer;
     uint private immutable exchangeRateToBackingPrecision;
 
     constructor(
@@ -26,8 +25,7 @@ contract AaveTempusPool is TempusPool {
         uint256 estYield,
         TokenData memory principalsData,
         TokenData memory yieldsData,
-        FeesConfig memory maxFeeSetup,
-        uint16 referrerCode
+        FeesConfig memory maxFeeSetup
     )
         TempusPool(
             address(token),
@@ -43,7 +41,6 @@ contract AaveTempusPool is TempusPool {
         )
     {
         aavePool = token.POOL();
-        referrer = referrerCode;
 
         uint8 underlyingDecimals = IERC20Metadata(token.UNDERLYING_ASSET_ADDRESS()).decimals();
         require(underlyingDecimals <= 18, "underlying decimals must be <= 18");
@@ -57,7 +54,12 @@ contract AaveTempusPool is TempusPool {
 
         // Deposit to AAVE
         IERC20(backingToken).safeIncreaseAllowance(address(aavePool), amount);
-        aavePool.deposit(address(backingToken), amount, address(this), referrer);
+        aavePool.deposit(
+            address(backingToken),
+            amount,
+            address(this),
+            0 /*referralCode*/
+        );
 
         return amount; // With Aave, the of YBT minted equals to the amount of deposited BT
     }

--- a/test/utils/TempusPool.ts
+++ b/test/utils/TempusPool.ts
@@ -219,8 +219,7 @@ export class TempusPool extends ContractBase {
           depositPercent:      yieldToken.toBigNum(0.5), // fees are stored in YBT
           earlyRedeemPercent:  yieldToken.toBigNum(1.0),
           matureRedeemPercent: yieldToken.toBigNum(0.5)
-        },
-        "0x00000" /* hardcoded referral code */
+        }
       );
     } else if (type === PoolType.Lido) {
       exchangeRatePrec = 18; // Lido is always 1e18 thanks to ETH


### PR DESCRIPTION
The referral program is dead: https://docs.aave.com/developers/v/1.0/integrating-aave/referral-program