### PR TITLE
Fix backing token for local deploy

### DIFF
--- a/scripts/deploy.local.fork.ts
+++ b/scripts/deploy.local.fork.ts
@@ -8,6 +8,7 @@ import { ContractBase, Signer } from '../test/utils/ContractBase';
 import { TempusController } from '../test/utils/TempusController';
 import { DAY, MONTH } from '../test/utils/TempusAMM';
 import { toWei } from '../test/utils/Decimal';
+import { ERC20Ether } from '../test/utils/ERC20Ether';
 
 export interface DeployedPoolInfo {
   address: string;
@@ -86,7 +87,7 @@ interface DeployPoolParams {
   poolType: PoolType;
   owner: Signer;
   backingToken: string;
-  bt: ERC20;
+  bt: ERC20 | ERC20Ether;
   ybt: ERC20;
   maturity: number;
   ybtName: string;
@@ -126,6 +127,7 @@ class DeployLocalForked {
   public async deploy() {
     this.owner = (await ethers.getSigners())[0];
 
+    const eth = new ERC20Ether();
     const Dai = new ERC20("ERC20FixedSupply", 18, (await ethers.getContract('Dai')));
     const Weth = new ERC20("ERC20", 18, (await ethers.getContract("Weth")));
 
@@ -147,7 +149,7 @@ class DeployLocalForked {
       poolType: PoolType.Lido,
       owner: this.owner,
       backingToken: 'ETH',
-      bt: Weth,
+      bt: eth,
       ybt: stETHToken,
       maturity: maturityTimeOneMonth,
       yieldEstimate: 0.01,
@@ -211,7 +213,7 @@ class DeployLocalForked {
       yieldShareAddress: pool.yieldShare.address,
       amm: tempusAMM.address,
       backingToken: params.backingToken,
-      backingTokenAddress: '0x0000000000000000000000000000000000000000',
+      backingTokenAddress: params.bt.address,
       yieldBearingTokenAddress: params.ybt.address,
       protocol: params.poolType,
       yieldBearingToken: params.ybtSymbol,

--- a/test/utils/ERC20Ether.ts
+++ b/test/utils/ERC20Ether.ts
@@ -8,6 +8,9 @@ import { IERC20 } from "./IERC20";
  * so that we can simplify tests on native ETH based pools
  */
 export class ERC20Ether extends DecimalConvertible implements IERC20 {
+  // Address of this contract - ETH is Zero address
+  address = '0x0000000000000000000000000000000000000000';
+
   constructor() {
     super(18);
   }


### PR DESCRIPTION
I'm not sure how anything worked with backing token address set to ETH, but the actual backing token of the pool was WETH. I was able to mint using ETH inside WETH pool 😕 