### PR TITLE
pool: Consistently use the type uint256 over uint

### DIFF
--- a/contracts/ITempusPool.sol
+++ b/contracts/ITempusPool.sol
@@ -236,12 +236,12 @@ interface ITempusPool is ITempusFees, IVersioned {
     /// @param yieldTokens Amount of YBT in YBT decimal precision
     /// @param interestRate The current interest rate
     /// @return Amount of Backing Tokens for specified @param yieldTokens
-    function numAssetsPerYieldToken(uint yieldTokens, uint interestRate) external view returns (uint);
+    function numAssetsPerYieldToken(uint256 yieldTokens, uint256 interestRate) external view returns (uint256);
 
     /// @dev This returns amount of YBT (Yield Bearing Tokens) that can be converted
     ///      from @param backingTokens Backing Tokens
     /// @param backingTokens Amount of Backing Tokens in BT decimal precision
     /// @param interestRate The current interest rate
     /// @return Amount of YBT for specified @param backingTokens
-    function numYieldTokensPerAsset(uint backingTokens, uint interestRate) external view returns (uint);
+    function numYieldTokensPerAsset(uint256 backingTokens, uint256 interestRate) external view returns (uint256);
 }

--- a/contracts/TempusController.sol
+++ b/contracts/TempusController.sol
@@ -450,13 +450,13 @@ contract TempusController is ReentrancyGuard, Ownable, Versioned {
         IERC20 yieldBearingToken = IERC20(targetPool.yieldBearingToken());
 
         // Transfer funds from msg.sender to targetPool
-        uint transferredYBT = yieldBearingToken.untrustedTransferFrom(
+        uint256 transferredYBT = yieldBearingToken.untrustedTransferFrom(
             msg.sender,
             address(targetPool),
             yieldTokenAmount
         );
 
-        (uint mintedShares, uint depositedBT, uint fee, uint rate) = targetPool.onDepositYieldBearing(
+        (uint256 mintedShares, uint256 depositedBT, uint256 fee, uint256 rate) = targetPool.onDepositYieldBearing(
             transferredYBT,
             recipient
         );
@@ -530,9 +530,14 @@ contract TempusController is ReentrancyGuard, Ownable, Versioned {
     ) private {
         require((principals > 0) || (yields > 0), "principalAmount and yieldAmount cannot both be 0");
 
-        (uint redeemedYBT, uint fee, uint interestRate) = targetPool.redeem(sender, principals, yields, recipient);
+        (uint256 redeemedYBT, uint256 fee, uint256 interestRate) = targetPool.redeem(
+            sender,
+            principals,
+            yields,
+            recipient
+        );
 
-        uint redeemedBT = targetPool.numAssetsPerYieldToken(redeemedYBT, targetPool.currentInterestRate());
+        uint256 redeemedBT = targetPool.numAssetsPerYieldToken(redeemedYBT, targetPool.currentInterestRate());
         bool earlyRedeem = !targetPool.matured();
         emit Redeemed(
             address(targetPool),
@@ -557,7 +562,7 @@ contract TempusController is ReentrancyGuard, Ownable, Versioned {
     ) private {
         require((principals > 0) || (yields > 0), "principalAmount and yieldAmount cannot both be 0");
 
-        (uint redeemedYBT, uint redeemedBT, uint fee, uint rate) = targetPool.redeemToBacking(
+        (uint256 redeemedYBT, uint256 redeemedBT, uint256 fee, uint256 rate) = targetPool.redeemToBacking(
             sender,
             principals,
             yields,

--- a/contracts/TempusPool.sol
+++ b/contracts/TempusPool.sol
@@ -418,7 +418,7 @@ abstract contract TempusPool is ITempusPool, ReentrancyGuard, Ownable, Versioned
     /// pricePerYield = currentYield * (estimatedYield - 1) / (estimatedYield)
     /// Return value decimal precision in backing token precision
     function pricePerYieldShare(uint256 currYield, uint256 estYield) private view returns (uint256) {
-        uint one = exchangeRateONE;
+        uint256 one = exchangeRateONE;
         // in case we have estimate for negative yield
         if (estYield < one) {
             return uint256(0);
@@ -520,10 +520,20 @@ abstract contract TempusPool is ITempusPool, ReentrancyGuard, Ownable, Versioned
     /// @return Stored Interest Rate, decimal precision depends on specific TempusPool implementation
     function currentInterestRate() public view virtual override returns (uint256);
 
-    function numYieldTokensPerAsset(uint backingTokens, uint interestRate) public view virtual override returns (uint);
+    function numYieldTokensPerAsset(uint256 backingTokens, uint256 interestRate)
+        public
+        view
+        virtual
+        override
+        returns (uint256);
 
-    function numAssetsPerYieldToken(uint yieldTokens, uint interestRate) public view virtual override returns (uint);
+    function numAssetsPerYieldToken(uint256 yieldTokens, uint256 interestRate)
+        public
+        view
+        virtual
+        override
+        returns (uint256);
 
     /// @return Converts an interest rate decimal into a Principal/Yield Share decimal
-    function interestRateToSharePrice(uint interestRate) internal view virtual returns (uint);
+    function interestRateToSharePrice(uint256 interestRate) internal view virtual returns (uint256);
 }

--- a/contracts/debug/Debug.sol
+++ b/contracts/debug/Debug.sol
@@ -21,15 +21,15 @@ library Debug {
     /// @param value The decimal value with precision defined by @param one
     /// @param one The base 1.0 value expressed in target decimal precision, eg 1e18
     function ftoa(uint256 value, uint256 one) internal pure returns (string memory) {
-        uint decimals = 0;
-        for (uint x = one / 10; x > 0; x = x / 10) {
+        uint256 decimals = 0;
+        for (uint256 x = one / 10; x > 0; x = x / 10) {
             ++decimals;
         }
 
         bytes memory buffer = new bytes(78); // uint256 has max 78 digits
-        uint len = 0;
-        for (uint i = 0; i < decimals; ++i) {
-            uint digit = value % 10;
+        uint256 len = 0;
+        for (uint256 i = 0; i < decimals; ++i) {
+            uint256 digit = value % 10;
             value = value / 10;
             buffer[len++] = bytes1(uint8(48 + digit));
         }
@@ -39,7 +39,7 @@ library Debug {
             buffer[len++] = bytes1(uint8(48)); // "0"
         } else {
             while (value != 0) {
-                uint digit = value % 10;
+                uint256 digit = value % 10;
                 value = value / 10;
                 buffer[len++] = bytes1(uint8(48 + digit));
             }
@@ -47,7 +47,7 @@ library Debug {
 
         // reverse the string
         bytes memory s = new bytes(len);
-        for (uint j = 0; j < len; j++) {
+        for (uint256 j = 0; j < len; j++) {
             s[j] = buffer[len - j - 1];
         }
         return string(s);

--- a/contracts/mocks/aave/AavePoolMock.sol
+++ b/contracts/mocks/aave/AavePoolMock.sol
@@ -61,7 +61,7 @@ contract AavePoolMock is ILendingPool {
     ///   is a different wallet
     function deposit(
         address asset,
-        uint amount,
+        uint256 amount,
         address onBehalfOf,
         uint16 /*referralCode*/
     ) public override {
@@ -77,7 +77,7 @@ contract AavePoolMock is ILendingPool {
         require(assetToken.transferFrom(msg.sender, assetOwner, amount), "transfer failed");
 
         // liquidity index controls how many additional tokens are minted
-        uint amountScaled = (amount).rayDiv(liquidityIndex);
+        uint256 amountScaled = (amount).rayDiv(liquidityIndex);
         yieldToken.mint(onBehalfOf, amountScaled);
     }
 

--- a/contracts/mocks/compound/CErc20.sol
+++ b/contracts/mocks/compound/CErc20.sol
@@ -24,22 +24,22 @@ contract CErc20 is CTokenMock, CErc20Interface {
     /// @notice Sender supplies assets into the market and receives cTokens in exchange
     /// @dev Accrues interest whether or not the operation succeeds, unless reverted
     /// @param mintAmount The amount of the underlying asset to supply
-    /// @return uint 0=success, otherwise a failure (see ErrorReporter.sol for details)
-    function mint(uint mintAmount) external override returns (uint) {
+    /// @return uint256 0=success, otherwise a failure (see ErrorReporter.sol for details)
+    function mint(uint256 mintAmount) external override returns (uint) {
         ComptrollerMock mock = ComptrollerMock(address(comptroller));
         if (mock.mockFailNextDepositOrRedeem()) {
             mock.setFailNextDepositOrRedeem(false);
             return 1;
         }
-        (uint err, ) = mintInternal(mintAmount);
+        (uint256 err, ) = mintInternal(mintAmount);
         return err;
     }
 
     /// @notice Sender redeems cTokens in exchange for the underlying asset
     /// @dev Accrues interest whether or not the operation succeeds, unless reverted
     /// @param redeemTokens The number of cTokens to redeem into underlying
-    /// @return uint 0=success, otherwise a failure (see ErrorReporter.sol for details)
-    function redeem(uint redeemTokens) external override returns (uint) {
+    /// @return uint256 0=success, otherwise a failure (see ErrorReporter.sol for details)
+    function redeem(uint256 redeemTokens) external override returns (uint) {
         ComptrollerMock mock = ComptrollerMock(address(comptroller));
         if (mock.mockFailNextDepositOrRedeem()) {
             mock.setFailNextDepositOrRedeem(false);
@@ -59,7 +59,7 @@ contract CErc20 is CTokenMock, CErc20Interface {
         return 0; // success
     }
 
-    function doTransferIn(address from, uint amount) internal override returns (uint) {
+    function doTransferIn(address from, uint256 amount) internal override returns (uint) {
         IERC20 backingToken = IERC20(underlying);
         backingToken.safeTransferFrom(from, address(this), amount);
         return amount;

--- a/contracts/mocks/compound/CTokenInterfaces.sol
+++ b/contracts/mocks/compound/CTokenInterfaces.sol
@@ -33,7 +33,7 @@ abstract contract CErc20Interface is CErc20Storage {
     /**
      * This is used to deposit into Compound with CErc20 tokens
      */
-    function mint(uint mintAmount) external virtual returns (uint);
+    function mint(uint256 mintAmount) external virtual returns (uint);
 
-    function redeem(uint redeemTokens) external virtual returns (uint);
+    function redeem(uint256 redeemTokens) external virtual returns (uint);
 }

--- a/contracts/mocks/compound/CTokenMock.sol
+++ b/contracts/mocks/compound/CTokenMock.sol
@@ -40,16 +40,19 @@ abstract contract CTokenMock is ERC20, CTokenInterface {
      * @return (uint, uint) An error code (0=success, otherwise a failure,
                see ErrorReporter.sol), and the actual mint amount in BackingToken decimals
      */
-    function mintInternal(uint mintAmount) internal returns (uint, uint) {
+    function mintInternal(uint256 mintAmount) internal returns (uint, uint) {
         // mintFresh emits the actual Mint event if successful and logs on errors, so we don't need to
         return mintFresh(msg.sender, mintAmount);
     }
 
-    function mintFresh(address minter, uint mintAmount) internal returns (uint errorCode, uint actualMintAmount) {
-        uint err = comptroller.mintAllowed(address(this), minter, mintAmount);
+    function mintFresh(address minter, uint256 mintAmount)
+        internal
+        returns (uint256 errorCode, uint256 actualMintAmount)
+    {
+        uint256 err = comptroller.mintAllowed(address(this), minter, mintAmount);
         require(err == 0, "mint is not allowed");
 
-        uint exchangeRate = exchangeRateStored(); // exchangeRate has variable decimal precision
+        uint256 exchangeRate = exchangeRateStored(); // exchangeRate has variable decimal precision
 
         /*
          *  We call `doTransferIn` for the minter and the mintAmount.
@@ -62,7 +65,7 @@ abstract contract CTokenMock is ERC20, CTokenInterface {
         actualMintAmount = doTransferIn(minter, mintAmount); // 18 decimal precision
 
         // exchange rate precision: 18 - 8 + Underlying Token Decimals
-        uint mintTokens = (actualMintAmount * 1e18) / exchangeRate; // (18 + 18) - 28 = 8 decimal precision
+        uint256 mintTokens = (actualMintAmount * 1e18) / exchangeRate; // (18 + 18) - 28 = 8 decimal precision
         _mint(minter, mintTokens);
         errorCode = 0;
     }
@@ -72,5 +75,5 @@ abstract contract CTokenMock is ERC20, CTokenInterface {
      *      transferred to the protocol, in case of a fee.
      *  This may revert due to insufficient balance or insufficient allowance.
      */
-    function doTransferIn(address from, uint amount) internal virtual returns (uint);
+    function doTransferIn(address from, uint256 amount) internal virtual returns (uint);
 }

--- a/contracts/mocks/compound/ComptrollerInterface.sol
+++ b/contracts/mocks/compound/ComptrollerInterface.sol
@@ -12,6 +12,6 @@ abstract contract ComptrollerInterface {
     function mintAllowed(
         address cToken,
         address minter,
-        uint mintAmount
+        uint256 mintAmount
     ) external virtual returns (uint);
 }

--- a/contracts/mocks/compound/ComptrollerMock.sol
+++ b/contracts/mocks/compound/ComptrollerMock.sol
@@ -8,19 +8,19 @@ import "./ComptrollerInterface.sol";
 import "./ComptrollerStorage.sol";
 
 contract ComptrollerMock is ComptrollerStorage, ComptrollerInterface {
-    uint public exchangeRate; // current exchange rate as 1**(18 - 8 + Underlying Token Decimals)
+    uint256 public exchangeRate; // current exchange rate as 1**(18 - 8 + Underlying Token Decimals)
 
     // used for mocks, it will force-fail the next deposit or redeem
     bool public mockFailNextDepositOrRedeem;
 
     /// @param initialExchangeRate Initial mocked exchange rate, the official default is 0.02
     ///                            with decimal precision calculated as 18 - 8 + Underlying Token Decimals
-    constructor(uint initialExchangeRate) {
+    constructor(uint256 initialExchangeRate) {
         exchangeRate = initialExchangeRate;
     }
 
     /// @notice MOCK ONLY
-    function setExchangeRate(uint rate) public {
+    function setExchangeRate(uint256 rate) public {
         exchangeRate = rate;
     }
 
@@ -33,9 +33,9 @@ contract ComptrollerMock is ComptrollerStorage, ComptrollerInterface {
     /// @param cTokens The list of addresses of the cToken markets to be enabled
     /// @return Success indicator for whether each corresponding market was entered
     function enterMarkets(address[] calldata cTokens) external override returns (uint[] memory) {
-        uint len = cTokens.length;
+        uint256 len = cTokens.length;
         uint[] memory results = new uint[](len);
-        for (uint i = 0; i < len; i++) {
+        for (uint256 i = 0; i < len; i++) {
             results[i] = uint(addToMarketInternal(CTokenMock(cTokens[i]), msg.sender));
         }
         return results;
@@ -69,9 +69,9 @@ contract ComptrollerMock is ComptrollerStorage, ComptrollerInterface {
         /* Delete cToken from the account’s list of assets */
         // load into memory for faster iteration
         CTokenMock[] memory userAssetList = accountAssets[msg.sender];
-        uint len = userAssetList.length;
-        uint assetIndex = len;
-        for (uint i = 0; i < len; i++) {
+        uint256 len = userAssetList.length;
+        uint256 assetIndex = len;
+        for (uint256 i = 0; i < len; i++) {
             if (userAssetList[i] == cToken) {
                 assetIndex = i;
                 break;
@@ -87,7 +87,7 @@ contract ComptrollerMock is ComptrollerStorage, ComptrollerInterface {
     function mintAllowed(
         address cToken,
         address minter,
-        uint /*mintAmount*/
+        uint256 /*mintAmount*/
     ) external view override returns (uint) {
         if (!isParticipant(cToken, minter)) {
             return 1; // error!

--- a/contracts/mocks/yearn/YearnVaultMock.sol
+++ b/contracts/mocks/yearn/YearnVaultMock.sol
@@ -64,7 +64,7 @@ contract YearnVaultMock is ERC20, IYearnVaultV2 {
 
         require(asset.transferFrom(msg.sender, address(this), amount), "transfer failed");
 
-        uint amountScaled = (amount).divfV(pricePerShare, pricePerShareDenominator);
+        uint256 amountScaled = (amount).divfV(pricePerShare, pricePerShareDenominator);
         _mint(msg.sender, amountScaled);
 
         return amountScaled;

--- a/contracts/pools/AaveTempusPool.sol
+++ b/contracts/pools/AaveTempusPool.sol
@@ -16,7 +16,7 @@ contract AaveTempusPool is TempusPool {
 
     ILendingPool internal immutable aavePool;
     bytes32 public constant override protocolName = "Aave";
-    uint private immutable exchangeRateToBackingPrecision;
+    uint256 private immutable exchangeRateToBackingPrecision;
 
     constructor(
         IAToken token,
@@ -96,16 +96,16 @@ contract AaveTempusPool is TempusPool {
     }
 
     /// NOTE: Aave AToken is pegged 1:1 with backing token
-    function numAssetsPerYieldToken(uint yieldTokens, uint) public pure override returns (uint) {
+    function numAssetsPerYieldToken(uint256 yieldTokens, uint256) public pure override returns (uint256) {
         return yieldTokens;
     }
 
     /// NOTE: Aave AToken is pegged 1:1 with backing token
-    function numYieldTokensPerAsset(uint backingTokens, uint) public pure override returns (uint) {
+    function numYieldTokensPerAsset(uint256 backingTokens, uint256) public pure override returns (uint256) {
         return backingTokens;
     }
 
-    function interestRateToSharePrice(uint interestRate) internal view override returns (uint) {
+    function interestRateToSharePrice(uint256 interestRate) internal view override returns (uint256) {
         return interestRate / exchangeRateToBackingPrecision;
     }
 }

--- a/contracts/pools/CompoundTempusPool.sol
+++ b/contracts/pools/CompoundTempusPool.sol
@@ -99,17 +99,17 @@ contract CompoundTempusPool is TempusPool {
 
     // NOTE: yieldTokens are in YieldToken precision, return value is in BackingToken precision
     //       This conversion happens automatically due to pre-scaled rate
-    function numAssetsPerYieldToken(uint yieldTokens, uint rate) public pure override returns (uint) {
+    function numAssetsPerYieldToken(uint256 yieldTokens, uint256 rate) public pure override returns (uint256) {
         return yieldTokens.mulfV(rate, 1e18);
     }
 
     // NOTE: backingTokens are in BackingToken precision, return value is in YieldToken precision
     //       This conversion happens automatically due to pre-scaled rate
-    function numYieldTokensPerAsset(uint backingTokens, uint rate) public pure override returns (uint) {
+    function numYieldTokensPerAsset(uint256 backingTokens, uint256 rate) public pure override returns (uint256) {
         return backingTokens.divfV(rate, 1e18);
     }
 
-    function interestRateToSharePrice(uint interestRate) internal pure override returns (uint) {
+    function interestRateToSharePrice(uint256 interestRate) internal pure override returns (uint256) {
         // rate is always (10 + backing.decimals), so converting back is always 1e10
         return interestRate / 1e10;
     }

--- a/contracts/pools/LidoTempusPool.sol
+++ b/contracts/pools/LidoTempusPool.sol
@@ -65,17 +65,17 @@ contract LidoTempusPool is TempusPool {
 
     /// NOTE: Lido StETH is pegged 1:1 to ETH
     /// @return Asset Token amount
-    function numAssetsPerYieldToken(uint yieldTokens, uint) public pure override returns (uint) {
+    function numAssetsPerYieldToken(uint256 yieldTokens, uint256) public pure override returns (uint256) {
         return yieldTokens;
     }
 
     /// NOTE: Lido StETH is pegged 1:1 to ETH
     /// @return YBT amount
-    function numYieldTokensPerAsset(uint backingTokens, uint) public pure override returns (uint) {
+    function numYieldTokensPerAsset(uint256 backingTokens, uint256) public pure override returns (uint256) {
         return backingTokens;
     }
 
-    function interestRateToSharePrice(uint interestRate) internal pure override returns (uint) {
+    function interestRateToSharePrice(uint256 interestRate) internal pure override returns (uint256) {
         return interestRate; // no conversion needed, praise ETH
     }
 }

--- a/contracts/pools/RariTempusPool.sol
+++ b/contracts/pools/RariTempusPool.sol
@@ -131,16 +131,16 @@ contract RariTempusPool is TempusPool {
         return lastCalculatedInterestRate;
     }
 
-    function numAssetsPerYieldToken(uint yieldTokens, uint rate) public view override returns (uint) {
+    function numAssetsPerYieldToken(uint256 yieldTokens, uint256 rate) public view override returns (uint) {
         return yieldTokens.mulfV(rate, exchangeRateONE) / exchangeRateToBackingPrecision;
     }
 
-    function numYieldTokensPerAsset(uint backingTokens, uint rate) public view override returns (uint) {
+    function numYieldTokensPerAsset(uint256 backingTokens, uint256 rate) public view override returns (uint) {
         return backingTokens.divfV(rate, exchangeRateONE) * exchangeRateToBackingPrecision;
     }
 
     /// @dev The rate precision is always 18
-    function interestRateToSharePrice(uint interestRate) internal view override returns (uint) {
+    function interestRateToSharePrice(uint256 interestRate) internal view override returns (uint) {
         return interestRate / exchangeRateToBackingPrecision;
     }
 

--- a/contracts/pools/YearnTempusPool.sol
+++ b/contracts/pools/YearnTempusPool.sol
@@ -81,16 +81,16 @@ contract YearnTempusPool is TempusPool {
         return yearnVault.pricePerShare();
     }
 
-    function numAssetsPerYieldToken(uint yieldTokens, uint rate) public view override returns (uint) {
+    function numAssetsPerYieldToken(uint256 yieldTokens, uint256 rate) public view override returns (uint256) {
         return yieldTokens.mulfV(rate, exchangeRateONE);
     }
 
-    function numYieldTokensPerAsset(uint backingTokens, uint rate) public view override returns (uint) {
+    function numYieldTokensPerAsset(uint256 backingTokens, uint256 rate) public view override returns (uint256) {
         return backingTokens.divfV(rate, exchangeRateONE);
     }
 
     /// @dev The rate precision always matches the BackingToken's precision
-    function interestRateToSharePrice(uint interestRate) internal pure override returns (uint) {
+    function interestRateToSharePrice(uint256 interestRate) internal pure override returns (uint256) {
         return interestRate;
     }
 }

--- a/contracts/protocols/aave/ILendingPool.sol
+++ b/contracts/protocols/aave/ILendingPool.sol
@@ -12,7 +12,7 @@ interface ILendingPool {
     ///   is a different wallet
     function deposit(
         address asset,
-        uint amount,
+        uint256 amount,
         address onBehalfOf,
         uint16 /*referralCode*/
     ) external;

--- a/contracts/protocols/compound/ICErc20.sol
+++ b/contracts/protocols/compound/ICErc20.sol
@@ -14,7 +14,7 @@ interface ICErc20 is ICToken {
     /// underlying tokens supplied, divided by the current Exchange Rate.
     /// @param mintAmount The amount of the asset to be supplied, in units of the underlying asset.
     /// @return 0 on success, otherwise an Error code
-    function mint(uint mintAmount) external returns (uint);
+    function mint(uint256 mintAmount) external returns (uint256);
 
     /// The redeem function converts a specified quantity of cTokens into the underlying asset, and returns
     /// them to the user. The amount of underlying tokens received is equal to the quantity of cTokens redeemed,
@@ -22,5 +22,5 @@ interface ICErc20 is ICToken {
     /// and the market's available liquidity.
     /// @param redeemTokens The number of cTokens to be redeemed.
     /// @return 0 on success, otherwise an Error code
-    function redeem(uint redeemTokens) external returns (uint);
+    function redeem(uint256 redeemTokens) external returns (uint256);
 }

--- a/contracts/protocols/compound/ICToken.sol
+++ b/contracts/protocols/compound/ICToken.sol
@@ -17,9 +17,9 @@ interface ICToken is IERC20, IERC20Metadata {
 
     /// Calculates and returns the current exchange rate.
     /// The decimal precision depends on the formula: 18 - 8 + Underlying Token Decimals
-    function exchangeRateCurrent() external returns (uint);
+    function exchangeRateCurrent() external returns (uint256);
 
     /// Calculates and returns the last stored rate.
     /// The decimal precision depends on the formula: 18 - 8 + Underlying Token Decimals
-    function exchangeRateStored() external view returns (uint);
+    function exchangeRateStored() external view returns (uint256);
 }

--- a/contracts/protocols/compound/IComptroller.sol
+++ b/contracts/protocols/compound/IComptroller.sol
@@ -9,5 +9,5 @@ interface IComptroller {
     /// @param cTokens The list of addresses of the cToken markets to be enabled
     /// @return For each market, returns an error code indicating whether or not it was entered.
     ///         Each is 0 on success, otherwise an Error code.
-    function enterMarkets(address[] calldata cTokens) external returns (uint[] memory);
+    function enterMarkets(address[] calldata cTokens) external returns (uint256[] memory);
 }

--- a/contracts/token/vesting/IERC20Vesting.sol
+++ b/contracts/token/vesting/IERC20Vesting.sol
@@ -73,5 +73,5 @@ interface IERC20Vesting {
     /// @dev Calculates the maximum amount of vested tokens that can be claimed for particular address
     /// @param receiver Address of token receiver
     /// @return Number of vested tokens one can claim
-    function claimable(address receiver) external view returns (uint);
+    function claimable(address receiver) external view returns (uint256);
 }


### PR DESCRIPTION
This ensures we use the types consistently, as currently we have a large mix.

Still, I have avoided touched the mocks, which is also using a mix.