### PR TITLE
pools: Use assert(msg.value == 0) in depositUnderlying in Rari

### DIFF
--- a/contracts/pools/RariTempusPool.sol
+++ b/contracts/pools/RariTempusPool.sol
@@ -71,7 +71,8 @@ contract RariTempusPool is TempusPool {
     }
 
     function depositToUnderlying(uint256 amount) internal override returns (uint256) {
-        require(msg.value == 0, "ETH deposits not supported");
+        // ETH deposits are not accepted, because it is rejected in the controller
+        assert(msg.value == 0);
 
         // Deposit to Rari Pool
         IERC20(backingToken).safeIncreaseAllowance(address(rariFundManager), amount);


### PR DESCRIPTION
This was missed from the last refactorings.