### PR TITLE
﻿refactor: remove old `pricePerXShare[Stored]()` overloads 

### DIFF
--- a/contracts/ITempusPool.sol
+++ b/contracts/ITempusPool.sol
@@ -216,20 +216,6 @@ interface ITempusPool is ITempusFees, IVersioned {
     ///         decimal precision depends on specific TempusPool implementation
     function maturityInterestRate() external view returns (uint256);
 
-    /// @return Rate of one Tempus Yield Share expressed in Asset Tokens
-    function pricePerYieldShare() external returns (uint256);
-
-    /// @return Rate of one Tempus Principal Share expressed in Asset Tokens
-    function pricePerPrincipalShare() external returns (uint256);
-
-    /// Calculated with stored interest rates
-    /// @return Rate of one Tempus Yield Share expressed in Asset Tokens,
-    function pricePerYieldShareStored() external view returns (uint256);
-
-    /// Calculated with stored interest rates
-    /// @return Rate of one Tempus Principal Share expressed in Asset Tokens
-    function pricePerPrincipalShareStored() external view returns (uint256);
-
     /// @dev Gets both Principals and Yields exchange rate, using updateInterestRate()
     /// @return principalsRate Rate of one Tempus Principal Share expressed in Asset Tokens.
     /// @return yieldsRate Rate of one Tempus Yield Share expressed in Asset Tokens.

--- a/contracts/TempusPool.sol
+++ b/contracts/TempusPool.sol
@@ -434,26 +434,6 @@ abstract contract TempusPool is ITempusPool, ReentrancyGuard, Ownable, Versioned
         return interestRateToSharePrice(principalPrice);
     }
 
-    function pricePerYieldShare() external override returns (uint256) {
-        uint256 yield = currentYield(updateInterestRate());
-        return pricePerYieldShare(yield, estimatedYield(yield));
-    }
-
-    function pricePerYieldShareStored() external view override returns (uint256) {
-        uint256 yield = currentYield(currentInterestRate());
-        return pricePerYieldShare(yield, estimatedYield(yield));
-    }
-
-    function pricePerPrincipalShare() external override returns (uint256) {
-        uint256 yield = currentYield(updateInterestRate());
-        return pricePerPrincipalShare(yield, estimatedYield(yield));
-    }
-
-    function pricePerPrincipalShareStored() external view override returns (uint256) {
-        uint256 yield = currentYield(currentInterestRate());
-        return pricePerPrincipalShare(yield, estimatedYield(yield));
-    }
-
     function getPricePerShare(uint256 interestRate) private view returns (uint256 principalsRate, uint256 yieldsRate) {
         uint256 curYield = currentYield(interestRate);
         uint256 estYield = estimatedYield(curYield);

--- a/contracts/amm/TempusAMM.sol
+++ b/contracts/amm/TempusAMM.sol
@@ -62,6 +62,8 @@ contract TempusAMM is BaseMinimalSwapInfoPool, StableMath, IRateProvider {
 
     IPoolShare internal immutable _token0;
     IPoolShare internal immutable _token1;
+    IPoolShare internal immutable _principals;
+    IPoolShare internal immutable _yields;
 
     // All token balances are normalized to behave as if the token had 18 decimals. We assume a token's decimals will
     // not change throughout its lifetime, and store the corresponding scaling factor for each at construction time.
@@ -123,8 +125,10 @@ contract TempusAMM is BaseMinimalSwapInfoPool, StableMath, IRateProvider {
         _require(amplificationStart >= _MIN_AMP, Errors.MIN_AMP);
         _require(amplificationStart <= _MAX_AMP, Errors.MAX_AMP);
 
-        IPoolShare yieldShare = pool.yieldShare();
         IPoolShare principalShare = pool.principalShare();
+        IPoolShare yieldShare = pool.yieldShare();
+        _principals = principalShare;
+        _yields = yieldShare;
 
         require(
             ERC20(address(principalShare)).decimals() == ERC20(address(yieldShare)).decimals(),
@@ -158,20 +162,29 @@ contract TempusAMM is BaseMinimalSwapInfoPool, StableMath, IRateProvider {
     }
 
     function getExpectedReturnGivenIn(uint256 amount, bool yieldShareIn) public view returns (uint256) {
+        (uint256 principalsRate, uint256 yieldsRate) = tempusPool.pricePerShareStored();
+        return _getExpectedReturnGivenIn(amount, principalsRate, yieldsRate, yieldShareIn);
+    }
+
+    function _getExpectedReturnGivenIn(
+        uint256 amount,
+        uint256 principalsRate,
+        uint256 yieldsRate,
+        bool yieldShareIn
+    ) private view returns (uint256) {
         (, uint256[] memory balances, ) = getVault().getPoolTokens(getPoolId());
         (uint256 currentAmp, ) = _getAmplificationParameter();
-        (IPoolShare tokenIn, IPoolShare tokenOut) = yieldShareIn
-            ? (tempusPool.yieldShare(), tempusPool.principalShare())
-            : (tempusPool.principalShare(), tempusPool.yieldShare());
+
+        IPoolShare tokenIn = yieldShareIn ? _yields : _principals;
         (uint256 indexIn, uint256 indexOut) = address(tokenIn) == address(_token0) ? (0, 1) : (1, 0);
+        (uint256 rateIn, uint256 rateOut) = yieldShareIn ? (yieldsRate, principalsRate) : (principalsRate, yieldsRate);
 
         amount = _subtractSwapFeeAmount(amount);
         balances.mul(_getTokenRatesStored(), _TEMPUS_SHARE_PRECISION);
-        uint256 rateAdjustedSwapAmount = (amount * tokenIn.getPricePerFullShareStored()) / _TEMPUS_SHARE_PRECISION;
+        uint256 rateAdjustedSwapAmount = (amount * rateIn) / _TEMPUS_SHARE_PRECISION;
 
         uint256 amountOut = StableMath._calcOutGivenIn(currentAmp, balances, indexIn, indexOut, rateAdjustedSwapAmount);
-        amountOut = (amountOut * _TEMPUS_SHARE_PRECISION) / tokenOut.getPricePerFullShareStored();
-
+        amountOut = (amountOut * _TEMPUS_SHARE_PRECISION) / rateOut;
         return amountOut;
     }
 
@@ -184,16 +197,14 @@ contract TempusAMM is BaseMinimalSwapInfoPool, StableMath, IRateProvider {
         (difference, yieldsIn) = (principals > yields) ? (principals - yields, false) : (yields - principals, true);
 
         if (difference > threshold) {
-            uint256 principalsRate = tempusPool.principalShare().getPricePerFullShareStored();
-            uint256 yieldsRate = tempusPool.yieldShare().getPricePerFullShareStored();
-
+            (uint256 principalsRate, uint256 yieldsRate) = tempusPool.pricePerShareStored();
             uint256 rate = yieldsIn
                 ? (principalsRate * _TEMPUS_SHARE_PRECISION) / yieldsRate
                 : (yieldsRate * _TEMPUS_SHARE_PRECISION) / principalsRate;
             for (uint256 i = 0; i < 32; i++) {
                 // if we have accurate rate this should hold
                 amountIn = (difference * _TEMPUS_SHARE_PRECISION) / (rate + _TEMPUS_SHARE_PRECISION);
-                uint256 amountOut = getExpectedReturnGivenIn(amountIn, yieldsIn);
+                uint256 amountOut = _getExpectedReturnGivenIn(amountIn, principalsRate, yieldsRate, yieldsIn);
                 uint256 newPrincipals = yieldsIn ? (principals + amountOut) : (principals - amountIn);
                 uint256 newYields = yieldsIn ? (yields - amountIn) : (yields + amountOut);
                 uint256 newDifference = (newPrincipals > newYields)
@@ -648,21 +659,24 @@ contract TempusAMM is BaseMinimalSwapInfoPool, StableMath, IRateProvider {
         _updateLastInvariant(StableMath._calculateInvariant(currentAmp, balances, true), currentAmp);
     }
 
-    /// @dev Creates 2 element array of token rates(pricePerFullshare)
-    /// @return rates Array of token rates
-    function _getTokenRates() private returns (uint256[] memory rates) {
-        rates = new uint256[](_TOTAL_TOKENS);
-        rates[0] = _token0.getPricePerFullShare();
-        // We already did updateInterestRate, so we can use stored values
-        rates[1] = _token1.getPricePerFullShareStored();
+    /// @dev Creates 2 element array of token rates(pricePerShare)
+    /// @return Array of token rates
+    function _getTokenRates() private returns (uint256[] memory) {
+        (uint256 principalsRate, uint256 yieldsRate) = tempusPool.pricePerShare();
+        uint256[] memory rates = new uint256[](_TOTAL_TOKENS);
+        rates[0] = principalsRate;
+        rates[1] = yieldsRate;
+        return rates;
     }
 
-    /// @dev Creates 2 element array of token rates(pricePerFullShareStored)
-    /// @return rates Array of stored token rates
-    function _getTokenRatesStored() private view returns (uint256[] memory rates) {
-        rates = new uint256[](_TOTAL_TOKENS);
-        rates[0] = _token0.getPricePerFullShareStored();
-        rates[1] = _token1.getPricePerFullShareStored();
+    /// @dev Creates 2 element array of token rates(pricePerShareStored)
+    /// @return Array of stored token rates
+    function _getTokenRatesStored() private view returns (uint256[] memory) {
+        (uint256 principalsRate, uint256 yieldsRate) = tempusPool.pricePerShareStored();
+        uint256[] memory rates = new uint256[](_TOTAL_TOKENS);
+        rates[0] = principalsRate;
+        rates[1] = yieldsRate;
+        return rates;
     }
 
     function getRate() external view override returns (uint256) {

--- a/contracts/amm/TempusAMM.sol
+++ b/contracts/amm/TempusAMM.sol
@@ -664,8 +664,9 @@ contract TempusAMM is BaseMinimalSwapInfoPool, StableMath, IRateProvider {
     function _getTokenRates() private returns (uint256[] memory) {
         (uint256 principalsRate, uint256 yieldsRate) = tempusPool.pricePerShare();
         uint256[] memory rates = new uint256[](_TOTAL_TOKENS);
-        rates[0] = principalsRate;
-        rates[1] = yieldsRate;
+        (rates[0], rates[1]) = address(_token0) == address(_principals)
+            ? (principalsRate, yieldsRate)
+            : (yieldsRate, principalsRate);
         return rates;
     }
 
@@ -674,8 +675,9 @@ contract TempusAMM is BaseMinimalSwapInfoPool, StableMath, IRateProvider {
     function _getTokenRatesStored() private view returns (uint256[] memory) {
         (uint256 principalsRate, uint256 yieldsRate) = tempusPool.pricePerShareStored();
         uint256[] memory rates = new uint256[](_TOTAL_TOKENS);
-        rates[0] = principalsRate;
-        rates[1] = yieldsRate;
+        (rates[0], rates[1]) = address(_token0) == address(_principals)
+            ? (principalsRate, yieldsRate)
+            : (yieldsRate, principalsRate);
         return rates;
     }
 

--- a/contracts/stats/Stats.sol
+++ b/contracts/stats/Stats.sol
@@ -24,16 +24,13 @@ contract Stats is ChainlinkTokenPairPriceFeed, Versioned {
         PoolShare yieldShare = PoolShare(address(pool.yieldShare()));
 
         uint256 backingTokenOne = pool.backingTokenONE();
-
-        uint256 pricePerPrincipalShare = pool.pricePerPrincipalShareStored();
-        uint256 pricePerYieldShare = pool.pricePerYieldShareStored();
-
+        (uint256 principalsRate, uint256 yieldsRate) = pool.pricePerShareStored();
         return
             calculateTvlInBackingTokens(
                 IERC20(address(principalShare)).totalSupply(),
                 IERC20(address(yieldShare)).totalSupply(),
-                pricePerPrincipalShare,
-                pricePerYieldShare,
+                principalsRate,
+                yieldsRate,
                 backingTokenOne
             );
     }

--- a/contracts/token/IPoolShare.sol
+++ b/contracts/token/IPoolShare.sol
@@ -17,11 +17,11 @@ interface IPoolShare {
     function pool() external view returns (ITempusPool);
 
     /// @dev Price per single share expressed in Backing Tokens of the underlying pool.
-    ///      This is for the purpose of TempusAMM api support.
     ///      Example: exchanging Tempus Yield Share to DAI
-    /// @return 1e18 decimal conversion rate per share
+    /// @return Rate of One Share conversion rate to Backing Tokens, in Backing Token decimal precision
     function getPricePerFullShare() external returns (uint256);
 
-    /// @return 1e18 decimal stored conversion rate per share
+    /// Calculated with stored interest rate
+    /// @return Rate of One Share conversion rate to Backing Tokens, in Backing Token decimal precision
     function getPricePerFullShareStored() external view returns (uint256);
 }

--- a/contracts/token/PrincipalShare.sol
+++ b/contracts/token/PrincipalShare.sol
@@ -15,12 +15,12 @@ contract PrincipalShare is PoolShare {
     // solhint-disable-previous-line no-empty-blocks
 
     function getPricePerFullShare() external override returns (uint256) {
-        (uint256 principalsRate,) = pool.pricePerShare();
+        (uint256 principalsRate, ) = pool.pricePerShare();
         return principalsRate;
     }
 
     function getPricePerFullShareStored() external view override returns (uint256) {
-        (uint256 principalsRate,) = pool.pricePerShareStored();
+        (uint256 principalsRate, ) = pool.pricePerShareStored();
         return principalsRate;
     }
 }

--- a/contracts/token/PrincipalShare.sol
+++ b/contracts/token/PrincipalShare.sol
@@ -14,13 +14,11 @@ contract PrincipalShare is PoolShare {
 
     // solhint-disable-previous-line no-empty-blocks
 
-    function getPricePerFullShare() external override returns (uint256) {
-        (uint256 principalsRate, ) = pool.pricePerShare();
-        return principalsRate;
+    function getPricePerFullShare() external override returns (uint256 principalsRate) {
+        (principalsRate, ) = pool.pricePerShare();
     }
 
-    function getPricePerFullShareStored() external view override returns (uint256) {
-        (uint256 principalsRate, ) = pool.pricePerShareStored();
-        return principalsRate;
+    function getPricePerFullShareStored() external view override returns (uint256 principalsRate) {
+        (principalsRate, ) = pool.pricePerShareStored();
     }
 }

--- a/contracts/token/PrincipalShare.sol
+++ b/contracts/token/PrincipalShare.sol
@@ -14,11 +14,13 @@ contract PrincipalShare is PoolShare {
 
     // solhint-disable-previous-line no-empty-blocks
 
-    function getPricePerFullShare() external override returns (uint256 principalsRate) {
-        (principalsRate, ) = pool.pricePerShare();
+    function getPricePerFullShare() external override returns (uint256) {
+        (uint256 principalsRate,) = pool.pricePerShare();
+        return principalsRate;
     }
 
-    function getPricePerFullShareStored() external view override returns (uint256 principalsRate) {
-        (principalsRate, ) = pool.pricePerShareStored();
+    function getPricePerFullShareStored() external view override returns (uint256) {
+        (uint256 principalsRate,) = pool.pricePerShareStored();
+        return principalsRate;
     }
 }

--- a/contracts/token/PrincipalShare.sol
+++ b/contracts/token/PrincipalShare.sol
@@ -15,10 +15,12 @@ contract PrincipalShare is PoolShare {
     // solhint-disable-previous-line no-empty-blocks
 
     function getPricePerFullShare() external override returns (uint256) {
-        return pool.pricePerPrincipalShare();
+        (uint256 principalsRate,) = pool.pricePerShare();
+        return principalsRate;
     }
 
     function getPricePerFullShareStored() external view override returns (uint256) {
-        return pool.pricePerPrincipalShareStored();
+        (uint256 principalsRate,) = pool.pricePerShareStored();
+        return principalsRate;
     }
 }

--- a/contracts/token/YieldShare.sol
+++ b/contracts/token/YieldShare.sol
@@ -14,13 +14,11 @@ contract YieldShare is PoolShare {
 
     // solhint-disable-previous-line no-empty-blocks
 
-    function getPricePerFullShare() external override returns (uint256) {
-        (, uint256 yieldsRate) = pool.pricePerShare();
-        return yieldsRate;
+    function getPricePerFullShare() external override returns (uint256 yieldsRate) {
+        (, yieldsRate) = pool.pricePerShare();
     }
 
-    function getPricePerFullShareStored() external view override returns (uint256) {
-        (, uint256 yieldsRate) = pool.pricePerShareStored();
-        return yieldsRate;
+    function getPricePerFullShareStored() external view override returns (uint256 yieldsRate) {
+        (, yieldsRate) = pool.pricePerShareStored();
     }
 }

--- a/contracts/token/YieldShare.sol
+++ b/contracts/token/YieldShare.sol
@@ -14,11 +14,13 @@ contract YieldShare is PoolShare {
 
     // solhint-disable-previous-line no-empty-blocks
 
-    function getPricePerFullShare() external override returns (uint256 yieldsRate) {
-        (, yieldsRate) = pool.pricePerShare();
+    function getPricePerFullShare() external override returns (uint256) {
+        (, uint256 yieldsRate) = pool.pricePerShare();
+        return yieldsRate;
     }
 
-    function getPricePerFullShareStored() external view override returns (uint256 yieldsRate) {
-        (, yieldsRate) = pool.pricePerShareStored();
+    function getPricePerFullShareStored() external view override returns (uint256) {
+        (, uint256 yieldsRate) = pool.pricePerShareStored();
+        return yieldsRate;
     }
 }

--- a/contracts/token/YieldShare.sol
+++ b/contracts/token/YieldShare.sol
@@ -15,10 +15,12 @@ contract YieldShare is PoolShare {
     // solhint-disable-previous-line no-empty-blocks
 
     function getPricePerFullShare() external override returns (uint256) {
-        return pool.pricePerYieldShare();
+        (, uint256 yieldsRate) = pool.pricePerShare();
+        return yieldsRate;
     }
 
     function getPricePerFullShareStored() external view override returns (uint256) {
-        return pool.pricePerYieldShareStored();
+        (, uint256 yieldsRate) = pool.pricePerShareStored();
+        return yieldsRate;
     }
 }

--- a/test/pool-utils/RariTestPool.ts
+++ b/test/pool-utils/RariTestPool.ts
@@ -16,10 +16,10 @@ export class RariTestPool extends PoolTestFixture {
   }
   async setInterestRate(rate:number): Promise<void> {
     await this.rari.setInterestRate(rate);
-    /// TODO: temporary hack - this getPricePerFullShare call is made to trigger updateInterestRate,
-    ///     which will in turn update the cached storedInterestRate
+    /// TODO: temporary hack - updateInterestRate will update the cached storedInterestRate
     /// Should be removed once Stats.sol exposes non-view methods that use the latest rate (then tests could be updated to use these).
-    await this.yields.contract.getPricePerFullShare(); 
+    /// TODO: this MUST be removed
+    await this.tempus.updateInterestRate();
   }
   async forceFailNextDepositOrRedeem(): Promise<void> {
     await this.rari.contract.setFailNextDepositOrRedeem(true);


### PR DESCRIPTION
from TempusPool and use new pricePerShare() instead