### PR TITLE
amm: Rename amplificationStart/amplificationEnd to amplificationStartValue/amplificationEndValue

### DIFF
--- a/contracts/amm/TempusAMM.sol
+++ b/contracts/amm/TempusAMM.sol
@@ -99,8 +99,8 @@ contract TempusAMM is BaseMinimalSwapInfoPool, StableMath, IRateProvider {
         string memory name,
         string memory symbol,
         ITempusPool pool,
-        uint256 amplificationStart,
-        uint256 amplificationEnd,
+        uint256 amplificationStartValue,
+        uint256 amplificationEndValue,
         uint256 swapFeePercentage,
         uint256 pauseWindowDuration,
         uint256 bufferPeriodDuration,
@@ -124,8 +124,8 @@ contract TempusAMM is BaseMinimalSwapInfoPool, StableMath, IRateProvider {
     {
         assert(_TOTAL_TOKENS == 2);
 
-        _require(amplificationStart >= _MIN_AMPLIFICATION, Errors.MIN_AMP);
-        _require(amplificationStart <= _MAX_AMPLIFICATION, Errors.MAX_AMP);
+        _require(amplificationStartValue >= _MIN_AMPLIFICATION, Errors.MIN_AMP);
+        _require(amplificationStartValue <= _MAX_AMPLIFICATION, Errors.MAX_AMP);
 
         IPoolShare yieldShare = pool.yieldShare();
         IPoolShare principalShare = pool.principalShare();
@@ -147,11 +147,11 @@ contract TempusAMM is BaseMinimalSwapInfoPool, StableMath, IRateProvider {
         _scalingFactor0 = _computeScalingFactor(IERC20(address(token0)));
         _scalingFactor1 = _computeScalingFactor(IERC20(address(token1)));
 
-        _setAmplificationData(amplificationStart);
+        _setAmplificationData(amplificationStartValue);
 
-        if (amplificationStart != amplificationEnd) {
-            _require(amplificationStart < amplificationEnd, Errors.MIN_AMP);
-            _startAmplificationParameterUpdate(amplificationEnd, pool.maturityTime());
+        if (amplificationStartValue != amplificationEndValue) {
+            _require(amplificationStartValue < amplificationEndValue, Errors.MIN_AMP);
+            _startAmplificationParameterUpdate(amplificationEndValue, pool.maturityTime());
         }
     }
 


### PR DESCRIPTION
It is easy to confuse it with timestamps otherwise.