### PR TITLE
amm: Fix Solidity version at 0.8.10 across the codebase

### DIFF
--- a/contracts/ITempusPool.sol
+++ b/contracts/ITempusPool.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.7.6 <0.9.0;
-pragma abicoder v2;
+pragma solidity 0.8.10;
 
 import "./token/IPoolShare.sol";
 import "./utils/IOwnable.sol";

--- a/contracts/amm/interfaces/IRateProvider.sol
+++ b/contracts/amm/interfaces/IRateProvider.sol
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity >=0.8.0;
+pragma solidity 0.8.10;
 
 interface IRateProvider {
     function getRate() external view returns (uint256);

--- a/contracts/amm/interfaces/ITempusAMM.sol
+++ b/contracts/amm/interfaces/ITempusAMM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.8.0;
+pragma solidity 0.8.10;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/amm/math/Math.sol
+++ b/contracts/amm/math/Math.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-
-pragma solidity ^0.8.0;
+pragma solidity 0.8.10;
 
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow checks.

--- a/contracts/amm/math/MockStableMath.sol
+++ b/contracts/amm/math/MockStableMath.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
-pragma solidity ^0.8.0;
+pragma solidity 0.8.10;
 
 import "./StableMath.sol";
 

--- a/contracts/amm/math/StableMath.sol
+++ b/contracts/amm/math/StableMath.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-
-pragma solidity ^0.8.0;
+pragma solidity 0.8.10;
 
 import "./Math.sol";
 import "../../math/Fixed256x18.sol";

--- a/contracts/debug/Debug.sol
+++ b/contracts/debug/Debug.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >0.7.0;
+pragma solidity 0.8.10;
 
 import "hardhat/console.sol";
 

--- a/contracts/math/Fixed256x18.sol
+++ b/contracts/math/Fixed256x18.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8.0;
+pragma solidity 0.8.10;
 
 library Fixed256x18 {
     uint256 internal constant ONE = 1e18; // 18 decimal places

--- a/contracts/math/MovingAverage.sol
+++ b/contracts/math/MovingAverage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.7.6;
+pragma solidity 0.8.10;
 
 /// State for Exponential Moving Average
 struct EMAState {

--- a/contracts/token/IPoolShare.sol
+++ b/contracts/token/IPoolShare.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.8.0;
+pragma solidity 0.8.10;
+
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
 import "../ITempusPool.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
 /// Interface of Tokens representing the principal or yield shares of a pool.
 interface IPoolShare is IERC20Metadata {

--- a/contracts/utils/IOwnable.sol
+++ b/contracts/utils/IOwnable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.7.6 <0.9.0;
+pragma solidity 0.8.10;
 
 /// Implements Ownable with a two step transfer of ownership
 interface IOwnable {

--- a/contracts/utils/IVersioned.sol
+++ b/contracts/utils/IVersioned.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.7.6 <0.9.0;
-pragma abicoder v2;
+pragma solidity 0.8.10;
 
 /// Implements versioning
 interface IVersioned {

--- a/contracts/utils/Versioned.sol
+++ b/contracts/utils/Versioned.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.7.6 <0.9.0;
+pragma solidity 0.8.10;
 
 import "./IVersioned.sol";
 

--- a/contracts/utils/mocks/MovingAverageMock.sol
+++ b/contracts/utils/mocks/MovingAverageMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.7.6;
+pragma solidity 0.8.10;
 
 import "../../math/MovingAverage.sol";
 


### PR DESCRIPTION
Some files are actually not locked to 0.8.x, but those are in the very minority. Not sure we should do this, but it does simplify thinking about dependencies.