### PR TITLE
amm: Removing TempusAMM init method.

### DIFF
--- a/contracts/amm/interfaces/ITempusAMM.sol
+++ b/contracts/amm/interfaces/ITempusAMM.sol
@@ -48,11 +48,6 @@ interface ITempusAMM is IERC20, IRateProvider, IOwnable {
     /// second token in TempusAMM pair
     function token1() external view returns (IPoolShare);
 
-    /// Initialises TempusAMM by adding initial liquidity it
-    /// @param amountToken0 Amount of token0 to init TempusAMM with
-    /// @param amountToken1 Amount of token0 to init TempusAMM with
-    function init(uint256 amountToken0, uint256 amountToken1) external;
-
     /// Adds liquidity to TempusAMM
     /// @param amountToken0 Amount of token0 to add to TempusAMM
     /// @param amountToken1 Amount of token0 to add to TempusAMM

--- a/test/PositionManager.test.ts
+++ b/test/PositionManager.test.ts
@@ -1,6 +1,5 @@
 import { expect } from "chai";
 import { ContractBase, Signer } from "./utils/ContractBase";
-import { TempusAMMJoinKind } from "./utils/TempusAMM";
 import { expectRevert } from "./utils/Utils";
 import { PoolType, TempusPool } from "./utils/TempusPool";
 import { describeForEachPool, integrationExclusiveIt as it } from "./pool-utils/MultiPoolTestSuite";
@@ -37,7 +36,7 @@ describeForEachPool("PositionManager", (testPool:PoolTestFixture) =>
   async function initAMM(user:Signer, ybtDeposit:number, principals:number, yields:number)
   {
     await testPool.tempus.controller.depositYieldBearing(user, pool, ybtDeposit, user);
-    await amm.provideLiquidity(user1, principals, yields, TempusAMMJoinKind.INIT);
+    await amm.provideLiquidity(user1, principals, yields);
   }
 
   it("verifies 3 user position mints followed by 3 burns completely empties the contract from Yields and Capitals", async () =>

--- a/test/TempusController.test.ts
+++ b/test/TempusController.test.ts
@@ -1,6 +1,5 @@
 import { expect } from "chai";
 import { addressOf, Signer } from "./utils/ContractBase";
-import { TempusAMMJoinKind } from "./utils/TempusAMM";
 import { expectRevert } from "./utils/Utils";
 import { PoolType, TempusPool } from "./utils/TempusPool";
 import { TempusController } from "./utils/TempusController";
@@ -52,7 +51,7 @@ describeForEachPool("TempusController", (testPool:PoolTestFixture) =>
   async function initAMM(user:Signer, ybtDeposit:number, principals:number, yields:number)
   {
     await controller.depositYieldBearing(user, pool, ybtDeposit, user);
-    await amm.provideLiquidity(user1, principals, yields, TempusAMMJoinKind.INIT);
+    await amm.provideLiquidity(user1, principals, yields);
   }
 
   async function expectValidState(expectedAMMBalancesRatio:BigNumber = null)
@@ -255,7 +254,7 @@ describeForEachPool("TempusController", (testPool:PoolTestFixture) =>
       await initAMM(user1, /*ybtDeposit*/1000000, /*principals*/100000, /*yields*/1000000);
 
       await controller.depositYieldBearing(user2, pool, 10000, user2);
-      await testPool.amm.provideLiquidity(user2, 1000, 10000, TempusAMMJoinKind.JOIN);
+      await testPool.amm.provideLiquidity(user2, 1000, 10000);
       
       const userP:number = +await testPool.principals.balanceOf(user2);
       const userY:number = +await testPool.yields.balanceOf(user2);
@@ -280,7 +279,7 @@ describeForEachPool("TempusController", (testPool:PoolTestFixture) =>
     {
       await initAMM(user1, /*ybtDeposit*/1000000, /*principals*/100000, /*yields*/1000000);
       await controller.depositYieldBearing(user2, pool, 10000, user2);
-      await testPool.amm.provideLiquidity(user2, 1000, 10000, TempusAMMJoinKind.JOIN);
+      await testPool.amm.provideLiquidity(user2, 1000, 10000);
       const userP:number = +await testPool.principals.balanceOf(user2);
       const userY:number = +await testPool.yields.balanceOf(user2);
       const userPRedeem:number = userP < 9999 ? userP : 9999;

--- a/test/amm/TempusAMM.test.ts
+++ b/test/amm/TempusAMM.test.ts
@@ -4,7 +4,6 @@ import { NumberOrString } from "../utils/Decimal";
 import { Signer } from "../utils/ContractBase";
 import { TempusPool } from "../utils/TempusPool";
 import { evmMine, evmSetAutomine, expectRevert, increaseTime, blockTimestamp } from "../utils/Utils";
-import { TempusAMMJoinKind } from "../utils/TempusAMM";
 import { describeForEachPool } from "../pool-utils/MultiPoolTestSuite";
 import { PoolTestFixture } from "../pool-utils/PoolTestFixture";
 import { TempusPoolAMM } from "../utils/TempusPoolAMM";
@@ -58,7 +57,7 @@ describeForEachPool("TempusAMM", (testFixture:PoolTestFixture) =>
     await testFixture.deposit(owner, depositAmount);
     await tempusPool.controller.depositYieldBearing(owner, tempusPool, depositAmount, owner);
     if (params.ammBalanceYield != undefined && params.ammBalancePrincipal != undefined) {
-      await tempusAMM.provideLiquidity(owner, params.ammBalancePrincipal, params.ammBalanceYield, TempusAMMJoinKind.INIT);
+      await tempusAMM.provideLiquidity(owner, params.ammBalancePrincipal, params.ammBalanceYield);
     }
     if (params.amplifyStart != params.amplifyEnd) {
       const oneAmplifyUpdate = (params.oneAmpUpdate === undefined) ? ONE_AMP_UPDATE_TIME : params.oneAmpUpdate;
@@ -219,7 +218,7 @@ describeForEachPool("TempusAMM", (testFixture:PoolTestFixture) =>
     
     try {
       const balanceLpBefore = +await testFixture.amm.balanceOf(owner);
-      await testFixture.amm.provideLiquidity(owner, 10, 100, TempusAMMJoinKind.JOIN);
+      await testFixture.amm.provideLiquidity(owner, 10, 100);
       await evmMine();
       const balanceLpAfter = +await testFixture.amm.balanceOf(owner);
       await evmMine();
@@ -261,7 +260,7 @@ describeForEachPool("TempusAMM", (testFixture:PoolTestFixture) =>
   it("checks invariant increases over time with adding liquidity", async () =>
   {
     await createPools({yieldEst:0.1, duration:ONE_MONTH, amplifyStart:5, amplifyEnd: 95, oneAmpUpdate: (ONE_MONTH / 90)});
-    await testFixture.amm.provideLiquidity(owner, 100, 1000, TempusAMMJoinKind.INIT);
+    await testFixture.amm.provideLiquidity(owner, 100, 1000);
     const amplificationParams = await testFixture.amm.getAmplificationParam();
     expect(amplificationParams.isUpdating).to.be.true;
   });
@@ -295,21 +294,21 @@ describeForEachPool("TempusAMM", (testFixture:PoolTestFixture) =>
 
     // stop update
     await tempusAMM.stopAmplificationUpdate();
-    await tempusAMM.provideLiquidity(owner, 100, 1000, TempusAMMJoinKind.INIT);
+    await tempusAMM.provideLiquidity(owner, 100, 1000);
   });
 
   it("revert on invalid join kind", async () =>
   {
     await createPools({yieldEst:0.1, duration:ONE_MONTH, amplifyStart:5, amplifyEnd:5});
-    await tempusAMM.provideLiquidity(owner, 100, 1000, TempusAMMJoinKind.INIT);
-    (await expectRevert(tempusAMM.provideLiquidity(owner, 100, 1000, TempusAMMJoinKind.INVALID)));
+    await tempusAMM.provideLiquidity(owner, 100, 1000);
+    (await expectRevert(tempusAMM.provideLiquidity(owner, 100, 1000)));
   });
 
   it("revert on join after maturity", async () =>
   {
     await createPools({yieldEst:0.1, duration:ONE_MONTH, amplifyStart:5, amplifyEnd:5});
     await testFixture.fastForwardToMaturity();
-    (await expectRevert(tempusAMM.provideLiquidity(owner, 100, 1000, TempusAMMJoinKind.INIT)));
+    (await expectRevert(tempusAMM.provideLiquidity(owner, 100, 1000)));
   });
 
   it("checks LP exiting pool", async () =>
@@ -356,7 +355,7 @@ describeForEachPool("TempusAMM", (testFixture:PoolTestFixture) =>
     expect(+underlyingBalanceOwner.token1).to.be.within(999.99, 1000);
     await tempusAMM.principalShare.transfer(owner, user.address, 1000);
     await tempusAMM.yieldShare.transfer(owner, user.address, 1000);
-    await tempusAMM.provideLiquidity(user, 100, 1000, TempusAMMJoinKind.JOIN);
+    await tempusAMM.provideLiquidity(user, 100, 1000);
 
     balanceUser = +await tempusAMM.balanceOf(user);
     balanceOwner = +await tempusAMM.balanceOf(owner);
@@ -380,7 +379,7 @@ describeForEachPool("TempusAMM", (testFixture:PoolTestFixture) =>
 
     await tempusAMM.principalShare.transfer(owner, user.address, 1000);
     await tempusAMM.yieldShare.transfer(owner, user.address, 1000);
-    await tempusAMM.provideLiquidity(user, 100, 1000, TempusAMMJoinKind.JOIN);
+    await tempusAMM.provideLiquidity(user, 100, 1000);
 
     expect(+await tempusAMM.balanceOf(user)).to.be.within(181, 182);
     expect(+await tempusAMM.getRate()).to.be.within(1.0019, 1.002);
@@ -398,7 +397,7 @@ describeForEachPool("TempusAMM", (testFixture:PoolTestFixture) =>
     // provide more liquidity with different user
     await tempusAMM.principalShare.transfer(owner, user1.address, 1000);
     await tempusAMM.yieldShare.transfer(owner, user1.address, 1000);
-    await tempusAMM.provideLiquidity(user1, 100, 1000, TempusAMMJoinKind.JOIN);
+    await tempusAMM.provideLiquidity(user1, 100, 1000);
     
     expect(+await tempusAMM.balanceOf(user1)).to.be.within(180, 181);
     expect(+await tempusAMM.getRate()).to.be.within(1.005975, 1.0060);

--- a/test/stats/Stats.test.ts
+++ b/test/stats/Stats.test.ts
@@ -5,7 +5,6 @@ import { describeForEachPool } from "../pool-utils/MultiPoolTestSuite";
 import { PoolTestFixture } from "../pool-utils/PoolTestFixture";
 import { Stats } from "../utils/Stats";
 import { TempusController } from "../utils/TempusController";
-import { TempusAMMJoinKind } from "../utils/TempusAMM";
 import { TempusPoolAMM } from "../utils/TempusPoolAMM";
 
 describeForEachPool("Stats", (testPool:PoolTestFixture) =>
@@ -20,7 +19,7 @@ describeForEachPool("Stats", (testPool:PoolTestFixture) =>
   async function initAMM(user:Signer, ybtDeposit:number, principals:number, yields:number)
   {
     await controller.depositYieldBearing(user, pool, ybtDeposit, user);
-    await amm.provideLiquidity(user1, principals, yields, TempusAMMJoinKind.INIT);
+    await amm.provideLiquidity(user1, principals, yields);
   }
 
   beforeEach(async () =>

--- a/test/utils/TempusAMM.ts
+++ b/test/utils/TempusAMM.ts
@@ -16,12 +16,6 @@ export const MONTH = DAY * 30;
 
 export const AMP_PRECISION = 1e3;
 
-export enum TempusAMMJoinKind {
-  INIT = 0,  // first join to the pool, needs to pick token balances
-  JOIN = 1,  // joining with exact amounts of both tokens
-  INVALID = -1,  // used to test invalid join type
-}
-
 export class TempusAMM extends ContractBase {
   token0: ERC20;
   token1: ERC20;
@@ -116,15 +110,10 @@ export class TempusAMM extends ContractBase {
     ));
   }
 
-  async provideLiquidity(from: Signer, token0Balance: Number, token1Balance: Number, joinKind: TempusAMMJoinKind) {
+  async provideLiquidity(from: Signer, token0Balance: Number, token1Balance: Number) {
     await this.token0.approve(from, this.address, token0Balance);
     await this.token1.approve(from, this.address, token1Balance);
-  
-    if (joinKind == TempusAMMJoinKind.INIT) {
-      await this.connect(from).init(this.token0.toBigNum(token0Balance), this.token1.toBigNum(token1Balance));
-    } else {
-      await this.connect(from).join(this.token0.toBigNum(token0Balance), this.token1.toBigNum(token1Balance), 0, from.address);
-    }
+    await this.connect(from).join(this.token0.toBigNum(token0Balance), this.token1.toBigNum(token1Balance), 0, from.address);
   }
 
   async exitPoolExactLpAmountIn(from: Signer, lpTokensAmount: Number) {

--- a/test/utils/TempusPoolAMM.ts
+++ b/test/utils/TempusPoolAMM.ts
@@ -1,7 +1,7 @@
 import { Contract } from "ethers";
 import { NumberOrString, toWei } from "./Decimal";
 import { ContractBase, Signer } from "./ContractBase";
-import { AMP_PRECISION, MONTH, TempusAMM, TempusAMMJoinKind } from "./TempusAMM";
+import { AMP_PRECISION, TempusAMM } from "./TempusAMM";
 import { PoolShare } from "./PoolShare";
 import { TempusController } from "./TempusController";
 
@@ -64,7 +64,7 @@ export class TempusPoolAMM extends TempusAMM {
     return super.getLPTokensInGivenTokensOut(principalStaked, yieldsStaked);
   }
 
-  async provideLiquidity(from: Signer, principals: Number, yields: Number, joinKind: TempusAMMJoinKind) {
-    await super.provideLiquidity(from, principals, yields, joinKind);
+  async provideLiquidity(from: Signer, principals: Number, yields: Number) {
+    await super.provideLiquidity(from, principals, yields);
   }
 }


### PR DESCRIPTION
Since one can call either `join` or `exit` I was thinking why not merge them to one method, where init logic is done when no liquidity, and join logic otherwise