### PR TITLE
refactor: renames `NumberOrString` to `Numberish`

### DIFF
--- a/test/MovingAverage.test.ts
+++ b/test/MovingAverage.test.ts
@@ -1,7 +1,7 @@
 import { Contract } from "ethers";
 import { ContractBase } from "./utils/ContractBase";
 import { expect } from "chai";
-import { NumberOrString, toWei } from "./utils/Decimal";
+import { Numberish, toWei } from "./utils/Decimal";
 import { increaseTime } from "./utils/Utils";
 import { describeNonPool } from "./pool-utils/MultiPoolTestSuite";
 
@@ -17,9 +17,9 @@ describeNonPool("MovingAverage", async () => {
 
     static async create(
       type:MAType,
-      updateInterval:NumberOrString,
-      newValueWeight:NumberOrString,
-      trendWeight:NumberOrString = 0
+      updateInterval:Numberish,
+      newValueWeight:Numberish,
+      trendWeight:Numberish = 0
     ): Promise<MovingAverageMock> {
       return new MovingAverageMock(await ContractBase.deployContract("MovingAverageMock",
         type.valueOf(),
@@ -29,12 +29,12 @@ describeNonPool("MovingAverage", async () => {
       ));
     }
 
-    async update(newValue:NumberOrString): Promise<NumberOrString> {
+    async update(newValue:Numberish): Promise<Numberish> {
       await this.contract.update(this.toBigNum(newValue));
       return this.value();
     }
 
-    async value(): Promise<NumberOrString> {
+    async value(): Promise<Numberish> {
       return this.fromBigNum(await this.contract.value());
     }
   }

--- a/test/TempusController.test.ts
+++ b/test/TempusController.test.ts
@@ -8,7 +8,7 @@ import { PoolTestFixture } from "./pool-utils/PoolTestFixture";
 import { BigNumber } from "@ethersproject/bignumber";
 import Decimal from "decimal.js";
 import { TempusPoolAMM } from "./utils/TempusPoolAMM";
-import { NumberOrString } from "./utils/Decimal";
+import { Numberish } from "./utils/Decimal";
 
 const SWAP_LIMIT_ERROR_MESSAGE = "slippage";
 
@@ -36,7 +36,7 @@ describeForEachPool("TempusController", (testPool:PoolTestFixture) =>
     return amm.toBigNum(1.0).mul(amm.toBigNum(principals)).div(amm.toBigNum(yields));
   }
 
-  function getDefaultLeftoverShares(): NumberOrString
+  function getDefaultLeftoverShares(): Numberish
   {
     if (pool.principalShare.decimals == 18) {
       return "0.000001";

--- a/test/amm/TempusAMM.test.ts
+++ b/test/amm/TempusAMM.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { BigNumber, Contract, ethers } from "ethers";
-import { NumberOrString } from "../utils/Decimal";
+import { Numberish } from "../utils/Decimal";
 import { Signer } from "../utils/ContractBase";
 import { TempusPool } from "../utils/TempusPool";
 import { evmMine, evmSetAutomine, expectRevert, increaseTime, blockTimestamp } from "../utils/Utils";
@@ -13,8 +13,8 @@ import { ContractBase } from "../utils/ContractBase";
 
 interface SwapTestRun {
   amplification:number;
-  swapAmountIn:NumberOrString;
-  swapAmountOut: NumberOrString;
+  swapAmountIn:Numberish;
+  swapAmountOut: Numberish;
   principalIn:boolean;
   givenOut?:boolean;
 }

--- a/test/pool-utils/PoolTestFixture.ts
+++ b/test/pool-utils/PoolTestFixture.ts
@@ -6,7 +6,7 @@ import { TempusPool, PoolType, TempusSharesNames, generateTempusSharesNames } fr
 import { blockTimestamp, setEvmTime, setNextBlockTimestamp } from "../utils/Utils";
 import { ERC20 } from "../utils/ERC20";
 import { IERC20 } from "../utils/IERC20";
-import { NumberOrString, formatDecimal } from "../utils/Decimal";
+import { Numberish, formatDecimal } from "../utils/Decimal";
 import { getRevertMessage } from "../utils/Utils";
 import { TempusController } from "../utils/TempusController";
 import { TempusPoolAMM } from "../utils/TempusPoolAMM";
@@ -210,14 +210,14 @@ export abstract class PoolTestFixture {
   /**
    * Deposit YieldBearingTokens into TempusPool
    */
-  async depositYBT(user:Signer, yieldBearingAmount:NumberOrString, recipient:SignerOrAddress = user): Promise<Transaction> {
+  async depositYBT(user:Signer, yieldBearingAmount:Numberish, recipient:SignerOrAddress = user): Promise<Transaction> {
     return this.tempus.controller.depositYieldBearing(user, this.tempus, yieldBearingAmount, recipient);
   }
 
   /**
    * Deposit BackingTokens into TempusPool
    */
-  async depositBT(user:Signer, backingTokenAmount:NumberOrString, recipient:SignerOrAddress = user, ethValue: NumberOrString = undefined): Promise<Transaction> {
+  async depositBT(user:Signer, backingTokenAmount:Numberish, recipient:SignerOrAddress = user, ethValue: Numberish = undefined): Promise<Transaction> {
     const ethToTransfer = this.acceptsEther ? ((ethValue == undefined) ? backingTokenAmount : ethValue) : (ethValue || 0);
     return this.tempus.controller.depositBacking(user, this.tempus, backingTokenAmount, recipient, ethToTransfer);
   }
@@ -225,14 +225,14 @@ export abstract class PoolTestFixture {
   /**
    * Redeems TempusShares to YieldBearingTokens
    */
-  async redeemToYBT(user:Signer, principalAmount:NumberOrString, yieldAmount:NumberOrString, recipient:SignerOrAddress = user): Promise<Transaction> {
+  async redeemToYBT(user:Signer, principalAmount:Numberish, yieldAmount:Numberish, recipient:SignerOrAddress = user): Promise<Transaction> {
     return this.tempus.controller.redeemToYieldBearing(user, this.tempus, principalAmount, yieldAmount, recipient);
   }
 
   /**
    * Redeems TempusShares to BackingTokens
    */
-  async redeemToBT(user:Signer, principalAmount:NumberOrString, yieldAmount:NumberOrString, recipient:SignerOrAddress = user): Promise<Transaction> {
+  async redeemToBT(user:Signer, principalAmount:Numberish, yieldAmount:Numberish, recipient:SignerOrAddress = user): Promise<Transaction> {
     return this.tempus.controller.redeemToBacking(user, this.tempus, principalAmount, yieldAmount, recipient);
   }
 
@@ -242,7 +242,7 @@ export abstract class PoolTestFixture {
    * @example (await pool.expectDepositYBT(user, 100)).to.equal('success');
    * @returns RevertMessage assertion, or 'success' assertion
    */
-  async expectDepositYBT(user:Signer, yieldBearingAmount:NumberOrString, recipient:SignerOrAddress = user): Promise<Chai.Assertion> {
+  async expectDepositYBT(user:Signer, yieldBearingAmount:Numberish, recipient:SignerOrAddress = user): Promise<Chai.Assertion> {
     try {
       await this.depositYBT(user, yieldBearingAmount, recipient);
       return expect('success');
@@ -257,7 +257,7 @@ export abstract class PoolTestFixture {
    * @example (await pool.expectDepositBT(user, 100)).to.equal('success');
    * @returns RevertMessage assertion, or 'success' assertion
    */
-  async expectDepositBT(user:Signer, backingTokenAmount:NumberOrString, recipient:SignerOrAddress = user, ethValue: NumberOrString = undefined): Promise<Chai.Assertion> {
+  async expectDepositBT(user:Signer, backingTokenAmount:Numberish, recipient:SignerOrAddress = user, ethValue: Numberish = undefined): Promise<Chai.Assertion> {
     try {
       await this.depositBT(user, backingTokenAmount, recipient, ethValue);
       return expect('success');
@@ -272,7 +272,7 @@ export abstract class PoolTestFixture {
    * @example (await pool.expectRedeemYBT(user, 100, 100)).to.equal('success');
    * @returns RevertMessage assertion, or 'success' assertion
    */
-  async expectRedeemYBT(user:Signer, principalShares:NumberOrString, yieldShares:NumberOrString, recipient:SignerOrAddress = user): Promise<Chai.Assertion> {
+  async expectRedeemYBT(user:Signer, principalShares:Numberish, yieldShares:Numberish, recipient:SignerOrAddress = user): Promise<Chai.Assertion> {
     try {
       await this.redeemToYBT(user, principalShares, yieldShares, recipient);
       return expect('success');
@@ -287,7 +287,7 @@ export abstract class PoolTestFixture {
    * @example (await pool.expectRedeemYBT(user, 100, 100)).to.equal('success');
    * @returns RevertMessage assertion, or 'success' assertion
    */
-  async expectRedeemBT(user:Signer, principalShares:NumberOrString, yieldShares:NumberOrString, recipient:SignerOrAddress = user): Promise<Chai.Assertion> {
+  async expectRedeemBT(user:Signer, principalShares:Numberish, yieldShares:Numberish, recipient:SignerOrAddress = user): Promise<Chai.Assertion> {
     try {
       await this.redeemToBT(user, principalShares, yieldShares, recipient);
       return expect('success');

--- a/test/utils/Aave.ts
+++ b/test/utils/Aave.ts
@@ -1,5 +1,5 @@
 import { Contract } from "ethers";
-import { NumberOrString, toRay, fromRay, parseDecimal } from "./Decimal";
+import { Numberish, toRay, fromRay, parseDecimal } from "./Decimal";
 import { ContractBase, SignerOrAddress, addressOf } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 import { TokenInfo } from "../pool-utils/TokenInfo";
@@ -33,14 +33,14 @@ export class Aave extends ContractBase {
   /**
    * @return Current Asset balance of the user as a decimal, eg. 1.0
    */
-  async assetBalance(user:SignerOrAddress): Promise<NumberOrString> {
+  async assetBalance(user:SignerOrAddress): Promise<Numberish> {
     return await this.asset.balanceOf(user);
   }
 
   /**
    * @return Yield Token balance of the user as a decimal, eg. 2.0
    */
-  async yieldBalance(user:SignerOrAddress): Promise<NumberOrString> {
+  async yieldBalance(user:SignerOrAddress): Promise<Numberish> {
     let wei = await this.contract.getDeposit(addressOf(user));
     return this.fromBigNum(wei);
   }
@@ -49,14 +49,14 @@ export class Aave extends ContractBase {
    * @return Current liquidity index of AAVE pool in RAY, which is 
    *         almost equivalent to reserve normalized income.
    */
-  async liquidityIndex(): Promise<NumberOrString> {
+  async liquidityIndex(): Promise<Numberish> {
     return fromRay(await this.contract.getReserveNormalizedIncome(this.asset.address));
   }
 
   /**
    * Sets the AAVE pool's MOCK liquidity index in RAY
    */
-  async setLiquidityIndex(liquidityIndex:NumberOrString, owner:SignerOrAddress = null) {
+  async setLiquidityIndex(liquidityIndex:Numberish, owner:SignerOrAddress = null) {
     if (owner !== null) {
       const prevLiquidityIndex = await this.liquidityIndex();
       const difference = (Number(liquidityIndex) / Number(prevLiquidityIndex)) - 1;
@@ -74,7 +74,7 @@ export class Aave extends ContractBase {
    * @param user User who wants to deposit ETH into AAVE Pool
    * @param amount # of ETH to deposit, eg: 1.0
    */
-  async deposit(user:SignerOrAddress, amount:NumberOrString) {
+  async deposit(user:SignerOrAddress, amount:Numberish) {
     await this.asset.approve(user, this.address, amount);
     await this.contract.connect(user).deposit(this.asset.address, this.toBigNum(amount), addressOf(user), 0);
   }

--- a/test/utils/Comptroller.ts
+++ b/test/utils/Comptroller.ts
@@ -1,5 +1,5 @@
 import { Contract, BigNumber } from "ethers";
-import { formatDecimal, NumberOrString, parseDecimal } from "./Decimal";
+import { formatDecimal, Numberish, parseDecimal } from "./Decimal";
 import { addressOf, ContractBase, SignerOrAddress } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 import { TokenInfo } from "../pool-utils/TokenInfo";
@@ -39,14 +39,14 @@ export class Comptroller extends ContractBase {
   /**
    * @return Current Asset balance of the user as a decimal, eg. 1.0
    */
-  async assetBalance(user:SignerOrAddress): Promise<NumberOrString> {
+  async assetBalance(user:SignerOrAddress): Promise<Numberish> {
     return await this.asset.balanceOf(user);
   }
 
   /**
    * @return Yield Token balance of the user as a decimal, eg. 2.0
    */
-  async yieldBalance(user:SignerOrAddress): Promise<NumberOrString> {
+  async yieldBalance(user:SignerOrAddress): Promise<Numberish> {
     return await this.yieldToken.balanceOf(user);
   }
 
@@ -54,14 +54,14 @@ export class Comptroller extends ContractBase {
    * @return Current Exchange Rate, converted from exchange rate decimal which has variable decimal precision
    *         The default initial exchange rate on compound is 0.02
    */
-  async exchangeRate(): Promise<NumberOrString> {
+  async exchangeRate(): Promise<Numberish> {
     return formatDecimal(await this.contract.exchangeRate(), this.ratePrecision);
   }
 
   /**
    * Sets the pool Exchange Rate, converting it to exchange rate decimal which has variable decimal precision
    */
-  async setExchangeRate(exchangeRate:NumberOrString, owner:SignerOrAddress = null): Promise<void> {
+  async setExchangeRate(exchangeRate:Numberish, owner:SignerOrAddress = null): Promise<void> {
     if (owner !== null) {
       const prevExchangeRate = await this.exchangeRate();
       const difference = (Number(exchangeRate) / Number(prevExchangeRate)) - 1;
@@ -108,14 +108,14 @@ export class Comptroller extends ContractBase {
    * @param user User to check
    * @param mintAmount How much he wants to mint
    */
-  async mintAllowed(user:SignerOrAddress, mintAmount:NumberOrString): Promise<boolean> {
+  async mintAllowed(user:SignerOrAddress, mintAmount:Numberish): Promise<boolean> {
     return await this.contract.mintAllowed(this.yieldToken.address, addressOf(user), this.asset.toBigNum(mintAmount)) == 0;
   }
 
   /**
    * Calls CErc20 mint() on the CToken, which means CToken must be CErc20 (like cDAI)
    */
-  async mint(user:SignerOrAddress, amount:NumberOrString) {
+  async mint(user:SignerOrAddress, amount:Numberish) {
     await this.asset.approve(user, this.yieldToken.address, amount);
     await this.yieldToken.contract.connect(user).mint(this.asset.toBigNum(amount));
   }

--- a/test/utils/Decimal.ts
+++ b/test/utils/Decimal.ts
@@ -1,7 +1,7 @@
 import { ethers } from "hardhat";
 import { BigNumber } from "ethers";
 
-export type NumberOrString = Number | string;
+export type Numberish = Number | string;
 
 /**
  * double has limited digits of accuracy, so any decimal 
@@ -28,7 +28,7 @@ export const ONE_WEI:BigNumber = ethers.utils.parseUnits('1.0', 18);
  * @param decimalBase Base precision of the decimal, for wei=18, for ray=27 
  * @returns BigNumber for use in solidity contracts
  */
-export function parseDecimal(decimal:NumberOrString, decimalBase:number): BigNumber {
+export function parseDecimal(decimal:Numberish, decimalBase:number): BigNumber {
   // need this special case to support MAX_UINT256, ignoring decimalBase
   const decimalString = decimal.toString();
   if (decimalString == MAX_UINT256) {
@@ -43,7 +43,7 @@ export function parseDecimal(decimal:NumberOrString, decimalBase:number): BigNum
  * @param decimalBase Base precision of the decimal, for wei=18, for ray=27
  * @returns Number for simple decimals like 2.5, string for long decimals "0.00000000000001"
  */
-export function formatDecimal(bigDecimal:BigNumber, decimalBase:number): NumberOrString {
+export function formatDecimal(bigDecimal:BigNumber, decimalBase:number): Numberish {
   const str = ethers.utils.formatUnits(bigDecimal, decimalBase);
   if (str.length <= MAX_NUMBER_DIGITS) 
     return Number(str);
@@ -51,27 +51,27 @@ export function formatDecimal(bigDecimal:BigNumber, decimalBase:number): NumberO
 }
 
 /** @return WEI BigNumber from an ETH decimal */
-export function toWei(eth:NumberOrString): BigNumber {
+export function toWei(eth:Numberish): BigNumber {
   return parseDecimal(eth.toString(), 18);
 }
 
 /** @return Decimal from a WEI BigNumber */
-export function fromWei(wei:BigNumber): NumberOrString {
+export function fromWei(wei:BigNumber): Numberish {
   return formatDecimal(wei, 18);
 }
 
 /** @return RAY BigNumber from a decimal number */
-export function toRay(decimal:NumberOrString): BigNumber {
+export function toRay(decimal:Numberish): BigNumber {
   return parseDecimal(decimal.toString(), 27);
 }
 
 /** @return Decimal from a RAY BigNumber */
-export function fromRay(wei:BigNumber): NumberOrString {
+export function fromRay(wei:BigNumber): Numberish {
   return formatDecimal(wei, 27);
 }
 
 /** @return ETH decimal from WEI BigNumber */
-export function toEth(wei:BigNumber): NumberOrString {
+export function toEth(wei:BigNumber): Numberish {
   return formatDecimal(wei, 18);
 }
 
@@ -88,7 +88,7 @@ export class DecimalConvertible {
   }
 
   /** @return Converts a Number or String into this Contract's BigNumber decimal */
-  public toBigNum(amount:NumberOrString):BigNumber {
+  public toBigNum(amount:Numberish):BigNumber {
     if (typeof(amount) === "string") {
       return parseDecimal(amount, this.decimals);
     }
@@ -100,7 +100,7 @@ export class DecimalConvertible {
   }
 
   /** @return Converts a BN big decimal of this Contract into a String or Number */
-  public fromBigNum(contractDecimal:BigNumber): NumberOrString {
+  public fromBigNum(contractDecimal:BigNumber): Numberish {
     return formatDecimal(contractDecimal, this.decimals);
   }
 }

--- a/test/utils/ERC20.ts
+++ b/test/utils/ERC20.ts
@@ -1,5 +1,5 @@
 import { Contract } from "ethers";
-import { NumberOrString } from "./Decimal";
+import { Numberish } from "./Decimal";
 import { ContractBase, SignerOrAddress, Signer, AbstractSigner, addressOf } from "./ContractBase";
 import { IERC20 } from "./IERC20";
 
@@ -80,7 +80,7 @@ export class ERC20 extends ContractBase implements IERC20 {
   /**
    * @returns Total supply of this ERC20 token as a decimal, such as 10.0
    */
-  async totalSupply(): Promise<NumberOrString> {
+  async totalSupply(): Promise<Numberish> {
     return this.fromBigNum(await this.contract.totalSupply());
   }
 
@@ -88,7 +88,7 @@ export class ERC20 extends ContractBase implements IERC20 {
    * @param account ERC20 account's address
    * @returns Balance of ERC20 address in decimals, eg 2.0
    */
-  async balanceOf(account:SignerOrAddress): Promise<NumberOrString> {
+  async balanceOf(account:SignerOrAddress): Promise<Numberish> {
     const amount = await this.contract.balanceOf(addressOf(account));
     return this.fromBigNum(amount);
   }
@@ -99,7 +99,7 @@ export class ERC20 extends ContractBase implements IERC20 {
    * @param recipient ERC20 transfer recipient's address
    * @param amount Amount of tokens to send in contract decimals, eg 2.0 or "0.00001"
    */
-  async transfer(sender:SignerOrAddress, recipient:SignerOrAddress, amount:NumberOrString): Promise<any> {
+  async transfer(sender:SignerOrAddress, recipient:SignerOrAddress, amount:Numberish): Promise<any> {
     const connected = this.connect(sender);
     return await connected.transfer(addressOf(recipient), this.toBigNum(amount));
   }
@@ -110,7 +110,7 @@ export class ERC20 extends ContractBase implements IERC20 {
    * @returns The remaining number of tokens that `spender` will be allowed to 
    * spend on behalf of `owner` through {transferFrom}. This is zero by default.
    */
-  async allowance(owner:SignerOrAddress, spender:SignerOrAddress): Promise<NumberOrString> {
+  async allowance(owner:SignerOrAddress, spender:SignerOrAddress): Promise<Numberish> {
     const amount = await this.contract.allowance(addressOf(owner), addressOf(spender));
     return this.fromBigNum(amount);
   }
@@ -121,7 +121,7 @@ export class ERC20 extends ContractBase implements IERC20 {
    * @param spender ERC20 approve's, spender's address
    * @param amount Amount of tokens to approve in contract decimals, eg 2.0 or "0.00001"
    */
-  async approve(caller:SignerOrAddress, spender:SignerOrAddress, amount:NumberOrString): Promise<any> {
+  async approve(caller:SignerOrAddress, spender:SignerOrAddress, amount:Numberish): Promise<any> {
     const connected = this.connect(caller);
     return await connected.approve(addressOf(spender), this.toBigNum(amount));
   }
@@ -133,13 +133,13 @@ export class ERC20 extends ContractBase implements IERC20 {
    * @param recipient ERC20 transferFrom recipient's address
    * @param amount Amount of tokens to send in contract decimals, eg 2.0 or "0.00001"
    */
-  async transferFrom(sender:SignerOrAddress, recipient:SignerOrAddress, amount:NumberOrString): Promise<any> {
+  async transferFrom(sender:SignerOrAddress, recipient:SignerOrAddress, amount:Numberish): Promise<any> {
     await this.contract.transferFrom(addressOf(sender), addressOf(recipient), this.toBigNum(amount));
   }
 
   /** Sends some ether directly to the contract,
    *  which is handled in the contract receive() function */
-  async sendToContract(signer:Signer, amount:NumberOrString) {
+  async sendToContract(signer:Signer, amount:Numberish) {
     return signer.sendTransaction({
       from: signer.address,
       to: this.contract.address,

--- a/test/utils/ERC20Ether.ts
+++ b/test/utils/ERC20Ether.ts
@@ -1,5 +1,5 @@
 import { ethers } from "hardhat";
-import { NumberOrString, DecimalConvertible } from "./Decimal";
+import { Numberish, DecimalConvertible } from "./Decimal";
 import { SignerOrAddress, Signer, addressOf } from "./ContractBase";
 import { IERC20 } from "./IERC20";
 
@@ -24,13 +24,13 @@ export class ERC20Ether extends DecimalConvertible implements IERC20 {
   /**
    * @returns Total supply of this ERC20 token as a decimal, such as 10.0
    */
-  async totalSupply(): Promise<NumberOrString> { return 117_766_454; }
+  async totalSupply(): Promise<Numberish> { return 117_766_454; }
 
   /**
    * @param account ERC20 account's address
    * @returns Balance of ERC20 address in decimals, eg 2.0
    */
-  async balanceOf(account:SignerOrAddress): Promise<NumberOrString> {
+  async balanceOf(account:SignerOrAddress): Promise<Numberish> {
     const balance = await ethers.provider.getBalance(addressOf(account));
     return this.fromBigNum(balance);
   }
@@ -41,7 +41,7 @@ export class ERC20Ether extends DecimalConvertible implements IERC20 {
    * @param recipient ERC20 transfer recipient's address
    * @param amount Amount of tokens to send in contract decimals, eg 2.0 or "0.00001"
    */
-  async transfer(sender:SignerOrAddress, recipient:SignerOrAddress, amount:NumberOrString): Promise<any> {
+  async transfer(sender:SignerOrAddress, recipient:SignerOrAddress, amount:Numberish): Promise<any> {
     const signer = <Signer>sender;
     return signer.sendTransaction({
       from: signer.address,
@@ -56,7 +56,7 @@ export class ERC20Ether extends DecimalConvertible implements IERC20 {
    * @returns The remaining number of tokens that `spender` will be allowed to 
    * spend on behalf of `owner` through {transferFrom}. This is zero by default.
    */
-  async allowance(owner:SignerOrAddress, spender:SignerOrAddress): Promise<NumberOrString> {
+  async allowance(owner:SignerOrAddress, spender:SignerOrAddress): Promise<Numberish> {
     return 0;
   }
   
@@ -66,7 +66,7 @@ export class ERC20Ether extends DecimalConvertible implements IERC20 {
    * @param spender ERC20 approve's, spender's address
    * @param amount Amount of tokens to approve in contract decimals, eg 2.0 or "0.00001"
    */
-  async approve(caller:SignerOrAddress, spender:SignerOrAddress, amount:NumberOrString): Promise<any> {
+  async approve(caller:SignerOrAddress, spender:SignerOrAddress, amount:Numberish): Promise<any> {
     return;
   }
 
@@ -77,7 +77,7 @@ export class ERC20Ether extends DecimalConvertible implements IERC20 {
    * @param recipient ERC20 transferFrom recipient's address
    * @param amount Amount of tokens to send in contract decimals, eg 2.0 or "0.00001"
    */
-  async transferFrom(sender:SignerOrAddress, recipient:SignerOrAddress, amount:NumberOrString): Promise<any> {
+  async transferFrom(sender:SignerOrAddress, recipient:SignerOrAddress, amount:Numberish): Promise<any> {
     return this.transfer(sender, recipient, amount);
   }
 }

--- a/test/utils/ERC20OwnerMintable.ts
+++ b/test/utils/ERC20OwnerMintable.ts
@@ -1,5 +1,5 @@
 import { Contract } from "ethers";
-import { NumberOrString } from "./Decimal";
+import { Numberish } from "./Decimal";
 import { SignerOrAddress, addressOf } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 
@@ -26,7 +26,7 @@ export class ERC20OwnerMintable extends ERC20 {
    * @param receiver Recipient address to mint tokens to
    * @param amount Number of tokens to mint
    */
-  async mint(sender:SignerOrAddress, receiver:SignerOrAddress, amount:NumberOrString) {
+  async mint(sender:SignerOrAddress, receiver:SignerOrAddress, amount:Numberish) {
     await this.connect(sender).mint(addressOf(receiver), this.toBigNum(amount));
   }
 
@@ -34,7 +34,7 @@ export class ERC20OwnerMintable extends ERC20 {
    * @param sender Account that is issuing the burn. Must be manager().
    * @param amount Number of tokens to burn
    */
-  async burn(sender:SignerOrAddress, amount:NumberOrString) {
+  async burn(sender:SignerOrAddress, amount:Numberish) {
     await this.connect(sender).burn(this.toBigNum(amount));
   }
 
@@ -43,7 +43,7 @@ export class ERC20OwnerMintable extends ERC20 {
    * @param account Source address to burn tokens from
    * @param amount Number of tokens to burn
    */
-  async burnFrom(sender:SignerOrAddress, account:SignerOrAddress, amount:NumberOrString) {
+  async burnFrom(sender:SignerOrAddress, account:SignerOrAddress, amount:Numberish) {
     await this.connect(sender).burnFrom(addressOf(account), this.toBigNum(amount));
   }
 }

--- a/test/utils/ERC20Vesting.ts
+++ b/test/utils/ERC20Vesting.ts
@@ -1,13 +1,13 @@
 import { Contract, Transaction } from "ethers";
-import { NumberOrString } from "./Decimal";
+import { Numberish } from "./Decimal";
 import { ContractBase, SignerOrAddress, Signer, addressOf } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 
 export interface VestingTerms {
   startTime:number;
   period:number;
-  amount: NumberOrString;
-  claimed: NumberOrString;
+  amount: Numberish;
+  claimed: Numberish;
 }
 
 /**
@@ -95,11 +95,11 @@ export class ERC20Vesting extends ContractBase {
     return this.connect(sender).transferVesting(addressOf(oldAddress), addressOf(newAddress));
   }
 
-  async claimable(receiver:SignerOrAddress): Promise<NumberOrString> {
+  async claimable(receiver:SignerOrAddress): Promise<Numberish> {
     return this.fromBigNum(await this.contract.claimable(addressOf(receiver)));
   }
 
-  async claim(sender:SignerOrAddress, amount?:NumberOrString): Promise<any> {
+  async claim(sender:SignerOrAddress, amount?:Numberish): Promise<any> {
     if (amount === undefined) {
       return this.connect(sender)['claim()']();
     } else {

--- a/test/utils/IERC20.ts
+++ b/test/utils/IERC20.ts
@@ -1,4 +1,4 @@
-import { NumberOrString } from "./Decimal";
+import { Numberish } from "./Decimal";
 import { SignerOrAddress } from "./ContractBase";
 import { BigNumber } from "@ethersproject/bignumber";
 
@@ -16,13 +16,13 @@ export interface IERC20 {
   symbol(): Promise<string>;
 
   /** @returns Total supply of this ERC20 token as a decimal, such as 10.0 */
-  totalSupply(): Promise<NumberOrString>;
+  totalSupply(): Promise<Numberish>;
 
   /**
    * @param account ERC20 account's address
    * @returns Balance of ERC20 address in decimals, eg 2.0
    */
-  balanceOf(account:SignerOrAddress): Promise<NumberOrString>;
+  balanceOf(account:SignerOrAddress): Promise<Numberish>;
 
   /**
    * @dev Moves `amount` tokens from the sender's account to `recipient`.
@@ -30,7 +30,7 @@ export interface IERC20 {
    * @param recipient ERC20 transfer recipient's address
    * @param amount Amount of tokens to send in contract decimals, eg 2.0 or "0.00001"
    */
-  transfer(sender:SignerOrAddress, recipient:SignerOrAddress, amount:NumberOrString): Promise<any>;
+  transfer(sender:SignerOrAddress, recipient:SignerOrAddress, amount:Numberish): Promise<any>;
 
   /**
    * @param owner ERC20 owner's address
@@ -38,7 +38,7 @@ export interface IERC20 {
    * @returns The remaining number of tokens that `spender` will be allowed to 
    * spend on behalf of `owner` through {transferFrom}. This is zero by default.
    */
-  allowance(owner:SignerOrAddress, spender:SignerOrAddress): Promise<NumberOrString>;
+  allowance(owner:SignerOrAddress, spender:SignerOrAddress): Promise<Numberish>;
 
   /**
    * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
@@ -46,7 +46,7 @@ export interface IERC20 {
    * @param spender ERC20 approve's, spender's address
    * @param amount Amount of tokens to approve in contract decimals, eg 2.0 or "0.00001"
    */
-  approve(caller:SignerOrAddress, spender:SignerOrAddress, amount:NumberOrString): Promise<any>;
+  approve(caller:SignerOrAddress, spender:SignerOrAddress, amount:Numberish): Promise<any>;
 
   /**
    * @dev Moves `amount` tokens from `sender` to `recipient` using the
@@ -55,11 +55,11 @@ export interface IERC20 {
    * @param recipient ERC20 transferFrom recipient's address
    * @param amount Amount of tokens to send in contract decimals, eg 2.0 or "0.00001"
    */
-  transferFrom(sender:SignerOrAddress, recipient:SignerOrAddress, amount:NumberOrString): Promise<any>;
+  transferFrom(sender:SignerOrAddress, recipient:SignerOrAddress, amount:Numberish): Promise<any>;
 
   /** @return Converts a Number or String into this Contract's BigNumber decimal */
-  toBigNum(amount:NumberOrString):BigNumber;
+  toBigNum(amount:Numberish):BigNumber;
 
   /** @return Converts a BN big decimal of this Contract into a String or Number */
-  fromBigNum(contractDecimal:BigNumber): NumberOrString;
+  fromBigNum(contractDecimal:BigNumber): Numberish;
 }

--- a/test/utils/LidoContract.ts
+++ b/test/utils/LidoContract.ts
@@ -1,6 +1,6 @@
 import { ethers } from "hardhat";
 import { BigNumber, Contract } from "ethers";
-import { formatDecimal, NumberOrString, parseDecimal } from "./Decimal";
+import { formatDecimal, Numberish, parseDecimal } from "./Decimal";
 import { SignerOrAddress, Signer, addressOf } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 import { ERC20Ether } from "./ERC20Ether";
@@ -16,27 +16,27 @@ export abstract class LidoContract extends ERC20 {
   }
 
   /** @return stETH balance of an user */
-  async sharesOf(user:SignerOrAddress): Promise<NumberOrString> {
+  async sharesOf(user:SignerOrAddress): Promise<Numberish> {
     return this.fromBigNum(await this.contract.sharesOf(addressOf(user)));
   }
 
   /** @return total stETH shares minted */
-  async getTotalShares(): Promise<NumberOrString> {
+  async getTotalShares(): Promise<Numberish> {
     return this.fromBigNum(await this.contract.getTotalShares());
   }
 
   /** @return the amount of Ether that corresponds to `_sharesAmount` token shares. */
-  async getPooledEthByShares(sharesAmount:NumberOrString): Promise<NumberOrString> {
+  async getPooledEthByShares(sharesAmount:Numberish): Promise<Numberish> {
     return this.fromBigNum(await this.contract.getPooledEthByShares(this.toBigNum(sharesAmount)));
   }
 
   /** @return the amount of shares that corresponds to `_ethAmount` protocol-controlled Ether. */
-  async getSharesByPooledEth(_ethAmount:NumberOrString): Promise<NumberOrString> {
+  async getSharesByPooledEth(_ethAmount:Numberish): Promise<Numberish> {
     return this.fromBigNum(await this.contract.getSharesByPooledEth(this.toBigNum(_ethAmount)));
   }
 
   /** @return total pooled ETH: beaconBalance + bufferedEther */
-  async totalSupply(): Promise<NumberOrString> {
+  async totalSupply(): Promise<Numberish> {
     return this.fromBigNum(await this.contract.totalSupply());
   }
 
@@ -49,7 +49,7 @@ export abstract class LidoContract extends ERC20 {
   }
 
   /** @return Stored Interest Rate */
-  async interestRate(): Promise<NumberOrString> {
+  async interestRate(): Promise<Numberish> {
     return this.fromBigNum(await this.interestRateBigNum());
   }
 
@@ -57,9 +57,9 @@ export abstract class LidoContract extends ERC20 {
    * Sets the pool Interest Rate
    * @param interestRate New synthetic Interest Rate
    */
-  abstract setInterestRate(interestRate:NumberOrString): Promise<void>;
+  abstract setInterestRate(interestRate:Numberish): Promise<void>;
 
-  async submit(signer:SignerOrAddress, amount:NumberOrString): Promise<NumberOrString> {
+  async submit(signer:SignerOrAddress, amount:Numberish): Promise<Numberish> {
     const val = this.toBigNum(amount); // payable call, set value:
     return await this.connect(signer).submit(addressOf(signer), {value: val})
   }

--- a/test/utils/LidoFork.ts
+++ b/test/utils/LidoFork.ts
@@ -1,6 +1,6 @@
 import { ethers } from "hardhat";
 import { BigNumber, Contract } from "ethers";
-import { NumberOrString, parseDecimal } from "./Decimal";
+import { Numberish, parseDecimal } from "./Decimal";
 import { setStorageField } from "./Utils";
 import { ERC20Ether } from "./ERC20Ether";
 import { TokenInfo } from "../pool-utils/TokenInfo";
@@ -44,7 +44,7 @@ export class LidoFork extends LidoContract {
    * beaconBalance value (which is a component of TotalETHSupply), and by scaling everything up we avoid the potential situation where we need to set beaconBalance
    * to a negative value to achieve the desired TargetETHSupply.
    */
-  async setInterestRate(interestRate:NumberOrString): Promise<void> {
+  async setInterestRate(interestRate:Numberish): Promise<void> {
     const totalETHSupply:BigNumber = await this.contract.totalSupply();
     
     const targetETHSupply = parseDecimal(interestRate, 36);

--- a/test/utils/LidoMock.ts
+++ b/test/utils/LidoMock.ts
@@ -1,5 +1,5 @@
 import { BigNumber, Contract } from "ethers";
-import { NumberOrString } from "./Decimal";
+import { Numberish } from "./Decimal";
 import { ContractBase } from "./ContractBase";
 import { ERC20Ether } from "./ERC20Ether";
 import { TokenInfo } from "../pool-utils/TokenInfo";
@@ -27,7 +27,7 @@ export class LidoMock extends LidoContract {
     return lido;
   }
 
-  async setInterestRate(interestRate:NumberOrString): Promise<void> {
+  async setInterestRate(interestRate:Numberish): Promise<void> {
     let totalETHSupply:BigNumber = await this.contract.totalSupply();
     // total ETH is 0, so we must actually deposit something, otherwise we can't manipulate the rate
     if (totalETHSupply.isZero()) {

--- a/test/utils/PoolShare.ts
+++ b/test/utils/PoolShare.ts
@@ -1,5 +1,5 @@
 import { Contract } from "ethers";
-import { NumberOrString } from "./Decimal";
+import { Numberish } from "./Decimal";
 import { ERC20OwnerMintable } from "./ERC20OwnerMintable";
 
 export enum ShareKind {
@@ -26,7 +26,7 @@ export class PoolShare extends ERC20OwnerMintable {
   /**
    * @returns Updates and gets price per share as described in PoolShare.sol
    */
-  async getPricePerFullShare(): Promise<NumberOrString> {
+  async getPricePerFullShare(): Promise<Numberish> {
     // this transaction will update latest PricePerFullShare
     await this.contract.getPricePerFullShare();
     return this.getPricePerFullShareStored(); // fetch the stored PPS
@@ -35,7 +35,7 @@ export class PoolShare extends ERC20OwnerMintable {
   /**
    * @returns Stored price per share as described in PoolShare.sol
    */
-  async getPricePerFullShareStored(): Promise<NumberOrString> {
+  async getPricePerFullShareStored(): Promise<Numberish> {
     return this.fromBigNum(await this.contract.getPricePerFullShareStored());
   }
 }

--- a/test/utils/RariFundManager.ts
+++ b/test/utils/RariFundManager.ts
@@ -1,5 +1,5 @@
 import { Contract } from "ethers";
-import { NumberOrString, parseDecimal } from "./Decimal";
+import { Numberish, parseDecimal } from "./Decimal";
 import { ContractBase, SignerOrAddress } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 import { TokenInfo } from "test/pool-utils/TokenInfo";
@@ -32,11 +32,11 @@ export class RariFundManager extends ContractBase {
     return new RariFundManager(rariFundManager, asset, yieldToken);
   }
 
-  async setInterestRate(interest:NumberOrString): Promise<void> { 
+  async setInterestRate(interest:Numberish): Promise<void> { 
     await this.contract.setInterestRate(parseDecimal(interest.toString(), 18));
   }
 
-  async deposit(user:SignerOrAddress, amount:NumberOrString): Promise<void> {
+  async deposit(user:SignerOrAddress, amount:Numberish): Promise<void> {
     await this.asset.approve(user, this.address, amount);
     await this.contract.connect(user).deposit((await this.asset.symbol()), this.asset.toBigNum(amount));
   }

--- a/test/utils/Stats.ts
+++ b/test/utils/Stats.ts
@@ -1,5 +1,5 @@
 import { Contract } from "ethers";
-import { NumberOrString, toWei } from "./Decimal";
+import { Numberish, toWei } from "./Decimal";
 import { ContractBase } from "./ContractBase";
 import { PoolTestFixture } from "../pool-utils/PoolTestFixture";
 
@@ -25,7 +25,7 @@ export class Stats extends ContractBase {
    * @return Amount of Principals (TPS) and Yields (TYS), scaled as 1e18 decimals.
    *         TPS and TYS are minted in 1:1 ratio, hence a single return value
    */
-  async estimatedMintedShares(pool:PoolTestFixture, amount:NumberOrString, isBackingToken:boolean): Promise<NumberOrString> {
+  async estimatedMintedShares(pool:PoolTestFixture, amount:Numberish, isBackingToken:boolean): Promise<Numberish> {
     const t = pool.tempus;
     const depositAmount = isBackingToken ? t.asset.toBigNum(amount) : t.yieldBearing.toBigNum(amount);
     return t.principalShare.fromBigNum(await this.contract.estimatedMintedShares(t.address, depositAmount, isBackingToken));
@@ -37,7 +37,7 @@ export class Stats extends ContractBase {
    * @param toBackingToken If true, redeem amount is estimated in BackingTokens instead of YieldBearingTokens
    * @return YBT or BT amount
    */
-  async estimatedRedeem(pool:PoolTestFixture, principals:NumberOrString, yields:NumberOrString, toBackingToken:boolean): Promise<NumberOrString> {
+  async estimatedRedeem(pool:PoolTestFixture, principals:Numberish, yields:Numberish, toBackingToken:boolean): Promise<Numberish> {
     const t = pool.tempus;
     const p = toBackingToken ? t.asset : t.yieldBearing;
     return p.fromBigNum(
@@ -58,9 +58,9 @@ export class Stats extends ContractBase {
    */
   async estimatedDepositAndProvideLiquidity(
     pool:PoolTestFixture,
-    amount:NumberOrString,
+    amount:Numberish,
     isBackingToken:boolean
-  ): Promise<[NumberOrString,NumberOrString,NumberOrString]> {
+  ): Promise<[Numberish,Numberish,Numberish]> {
     const t = pool.tempus;
     const tuple = await this.contract.estimatedDepositAndProvideLiquidity(
       pool.amm.address, pool.tempus.address, isBackingToken ? t.toBigNum(amount) : t.yieldBearing.toBigNum(amount), isBackingToken
@@ -72,7 +72,7 @@ export class Stats extends ContractBase {
     ];
   }
   
-  async estimatedDepositAndFix(pool:PoolTestFixture, amount:NumberOrString, isBackingToken:boolean): Promise<NumberOrString> {
+  async estimatedDepositAndFix(pool:PoolTestFixture, amount:Numberish, isBackingToken:boolean): Promise<Numberish> {
     const t = pool.tempus;
     return t.principalShare.fromBigNum(
       await this.contract.estimatedDepositAndFix(
@@ -81,7 +81,7 @@ export class Stats extends ContractBase {
     );
   }
 
-  async estimatedDepositAndLeverage(pool:PoolTestFixture, amount:NumberOrString, isBackingToken:boolean, leverage:NumberOrString): Promise<[NumberOrString,NumberOrString]> {
+  async estimatedDepositAndLeverage(pool:PoolTestFixture, amount:Numberish, isBackingToken:boolean, leverage:Numberish): Promise<[Numberish,Numberish]> {
     const t = pool.tempus;
     
     const principalsYields = await this.contract.estimatedDepositAndLeverage(
@@ -100,11 +100,11 @@ export class Stats extends ContractBase {
 
   async estimateExitAndRedeem(
     pool:PoolTestFixture,
-    lpTokens:NumberOrString,
-    principals:NumberOrString,
-    yields:NumberOrString,
+    lpTokens:Numberish,
+    principals:Numberish,
+    yields:Numberish,
     toBackingToken:boolean
-  ): Promise<NumberOrString> {
+  ): Promise<Numberish> {
     const t = pool.tempus;
     const p = toBackingToken ? t : t.yieldBearing;
     const r = await this.contract.estimateExitAndRedeem(
@@ -121,12 +121,12 @@ export class Stats extends ContractBase {
 
   async estimateExitAndRedeemGivenStakedOut(
     pool:PoolTestFixture,
-    principals:NumberOrString,
-    yields:NumberOrString,
-    principalStaked:NumberOrString,
-    yieldsStaked:NumberOrString,
+    principals:Numberish,
+    yields:Numberish,
+    principalStaked:Numberish,
+    yieldsStaked:Numberish,
     toBackingToken:boolean
-  ): Promise<{ tokenAmount:NumberOrString, lpTokensRedeemed:NumberOrString }> {
+  ): Promise<{ tokenAmount:Numberish, lpTokensRedeemed:Numberish }> {
     const t = pool.tempus;
     const p = toBackingToken ? t : t.yieldBearing;
     const r = await this.contract.estimateExitAndRedeemGivenStakedOut(

--- a/test/utils/TempusAMM.ts
+++ b/test/utils/TempusAMM.ts
@@ -1,6 +1,6 @@
 import { ethers } from "hardhat";
 import { BigNumber, Contract, Transaction } from "ethers";
-import { NumberOrString, toWei } from "./Decimal";
+import { Numberish, toWei } from "./Decimal";
 import { ContractBase, Signer } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 import { blockTimestamp, setEvmTime } from "./Utils";
@@ -61,36 +61,36 @@ export class TempusAMM extends ContractBase {
     return new TempusAMM(tempusAMM, token0, token1);
   }
 
-  async balanceOf(user:Signer): Promise<NumberOrString> {
+  async balanceOf(user:Signer): Promise<Numberish> {
     return this.fromBigNum(await this.contract.balanceOf(user.address));
   }
 
   /**
    * @dev Returns the amount of token0/token1 the users' LP tokens represent.
    */
-  async compositionBalanceOf(user:Signer): Promise<{token0: NumberOrString, token1: NumberOrString}> {
+  async compositionBalanceOf(user:Signer): Promise<{token0: Numberish, token1: Numberish}> {
     const [token0, token1] = await this.contract.compositionBalanceOf(user.address);
     return {token0: this.token0.fromBigNum(token0), token1: this.token1.fromBigNum(token1)};
   }
 
-  async totalSupply(): Promise<NumberOrString> {
+  async totalSupply(): Promise<Numberish> {
     return this.fromBigNum(await this.contract.totalSupply());
   }
 
-  async getRate(): Promise<NumberOrString> {
+  async getRate(): Promise<Numberish> {
     return this.fromBigNum(await this.contract.getRate());
   }
 
-  async getExpectedReturnGivenIn(inAmount: NumberOrString, tokenIn: PoolShare) : Promise<NumberOrString> {
+  async getExpectedReturnGivenIn(inAmount: Numberish, tokenIn: PoolShare) : Promise<Numberish> {
     return tokenIn.fromBigNum(await this.contract.getExpectedReturnGivenIn(tokenIn.toBigNum(inAmount), tokenIn.address));
   }
 
-  async getTokensOutGivenLPIn(inAmount: NumberOrString): Promise<{token0Out:number, token1Out:number}> {
+  async getTokensOutGivenLPIn(inAmount: Numberish): Promise<{token0Out:number, token1Out:number}> {
     const p = await this.contract.getTokensOutGivenLPIn(this.toBigNum(inAmount));
     return {token0Out: +this.token0.fromBigNum(p.token0Out), token1Out: +this.token1.fromBigNum(p.token1Out)};
   }
 
-  async getLPTokensOutForTokensIn(token0AmountIn:NumberOrString, token1AmountIn:NumberOrString): Promise<NumberOrString> {
+  async getLPTokensOutForTokensIn(token0AmountIn:Numberish, token1AmountIn:Numberish): Promise<Numberish> {
     return +this.fromBigNum(await this.contract.getLPTokensOutForTokensIn(
       this.token0.toBigNum(token0AmountIn),
       this.token1.toBigNum(token1AmountIn)
@@ -103,7 +103,7 @@ export class TempusAMM extends ContractBase {
    * @param token1Out amount of Token1 to withdraw
    * @return lpTokens Amount of Lp tokens that user would redeem
    */
-  async getLPTokensInGivenTokensOut(token0Out:NumberOrString, token1Out:NumberOrString): Promise<NumberOrString> {
+  async getLPTokensInGivenTokensOut(token0Out:Numberish, token1Out:Numberish): Promise<Numberish> {
     return this.fromBigNum(await this.contract.getLPTokensInGivenTokensOut(
       this.token0.toBigNum(token0Out),
       this.token1.toBigNum(token1Out)
@@ -129,7 +129,7 @@ export class TempusAMM extends ContractBase {
     );
   }
 
-  async swapGivenInOrOut(from: Signer, assetIn: string, assetOut: string, amount: NumberOrString, givenOut?:boolean) {
+  async swapGivenInOrOut(from: Signer, assetIn: string, assetOut: string, amount: Numberish, givenOut?:boolean) {
     await this.token0.approve(from, this.address, await this.token0.balanceOf(from));
     await this.token1.approve(from, this.address, await this.token1.balanceOf(from));
     const SWAP_KIND = (givenOut !== undefined && givenOut) ? 1 : 0;
@@ -183,7 +183,7 @@ export class TempusAMM extends ContractBase {
     return this.contract.stopAmplificationParameterUpdate();
   }
 
-  async getAmplificationParam(): Promise<{value:NumberOrString, isUpdating:NumberOrString, precision:NumberOrString}> {
+  async getAmplificationParam(): Promise<{value:Numberish, isUpdating:Numberish, precision:Numberish}> {
     return this.contract.getAmplificationParameter();
   }
 }

--- a/test/utils/TempusController.ts
+++ b/test/utils/TempusController.ts
@@ -1,5 +1,5 @@
 import { Contract, Transaction } from "ethers";
-import { NumberOrString, toWei } from "./Decimal";
+import { Numberish, toWei } from "./Decimal";
 import { ContractBase, Signer, SignerOrAddress, addressOf } from "./ContractBase";
 import { TempusPool } from "./TempusPool";
 import { PoolTestFixture } from "../pool-utils/PoolTestFixture";
@@ -66,7 +66,7 @@ export class TempusController extends ContractBase {
    * @param recipient Address or User who will receive the minted shares
    * @param ethValue value of ETH to send with the tx
    */
-  async depositYieldBearing(user:SignerOrAddress, pool: TempusPool, yieldBearingAmount:NumberOrString, recipient:SignerOrAddress = user, ethValue: NumberOrString = 0): Promise<Transaction> {
+  async depositYieldBearing(user:SignerOrAddress, pool: TempusPool, yieldBearingAmount:Numberish, recipient:SignerOrAddress = user, ethValue: Numberish = 0): Promise<Transaction> {
     await pool.yieldBearing.approve(user, this.contract.address, yieldBearingAmount);
     return this.connect(user).depositYieldBearing(
       pool.address, pool.yieldBearing.toBigNum(yieldBearingAmount),
@@ -82,7 +82,7 @@ export class TempusController extends ContractBase {
   * @param recipient Address or User who will receive the minted shares
   * @param ethValue value of ETH to send with the tx
   */
-  async depositBacking(user:SignerOrAddress, pool: TempusPool, backingAmount:NumberOrString, recipient:SignerOrAddress = user, ethValue: NumberOrString = 0): Promise<Transaction> {
+  async depositBacking(user:SignerOrAddress, pool: TempusPool, backingAmount:Numberish, recipient:SignerOrAddress = user, ethValue: Numberish = 0): Promise<Transaction> {
     return this.connect(user).depositBacking(
       pool.address, pool.asset.toBigNum(backingAmount),
       addressOf(recipient), { value: toWei(ethValue) }
@@ -97,7 +97,7 @@ export class TempusController extends ContractBase {
    * @param yieldAmount How many yield shares to redeem
    * @param recipient The recipient address (can be user)
    */
-  async redeemToBacking(user:SignerOrAddress, pool: TempusPool, principalAmount:NumberOrString, yieldAmount:NumberOrString, recipient:SignerOrAddress): Promise<Transaction> {
+  async redeemToBacking(user:SignerOrAddress, pool: TempusPool, principalAmount:Numberish, yieldAmount:Numberish, recipient:SignerOrAddress): Promise<Transaction> {
     return this.connect(user).redeemToBacking(
       pool.address, pool.principalShare.toBigNum(principalAmount), pool.yieldShare.toBigNum(yieldAmount), addressOf(recipient)
     );
@@ -111,7 +111,7 @@ export class TempusController extends ContractBase {
    * @param yieldAmount How many yield shares to redeem
    * @param recipient The recipient address (can be user)
    */
-  async redeemToYieldBearing(user:SignerOrAddress, pool: TempusPool, principalAmount:NumberOrString, yieldAmount:NumberOrString, recipient:SignerOrAddress): Promise<Transaction> {
+  async redeemToYieldBearing(user:SignerOrAddress, pool: TempusPool, principalAmount:Numberish, yieldAmount:Numberish, recipient:SignerOrAddress): Promise<Transaction> {
     return this.connect(user).redeemToYieldBearing(
       pool.address, pool.principalShare.toBigNum(principalAmount), pool.yieldShare.toBigNum(yieldAmount), addressOf(recipient)
     );
@@ -120,7 +120,7 @@ export class TempusController extends ContractBase {
   /**
    * Approves either BT or YBT transfer
    */
-  async approve(pool:PoolTestFixture, user:SignerOrAddress, amount:NumberOrString, isBackingToken:boolean) {
+  async approve(pool:PoolTestFixture, user:SignerOrAddress, amount:Numberish, isBackingToken:boolean) {
     const token = isBackingToken ? pool.asset : pool.ybt;
     await token.approve(user, this.address, amount);
   }
@@ -137,9 +137,9 @@ export class TempusController extends ContractBase {
   async depositAndProvideLiquidity(
     pool: PoolTestFixture,
     user: SignerOrAddress,
-    tokenAmount: NumberOrString,
+    tokenAmount: Numberish,
     isBackingToken: boolean,
-    ethValue: NumberOrString = 0
+    ethValue: Numberish = 0
   ): Promise<Transaction> {
     await this.approve(pool, user, tokenAmount, isBackingToken);
     const amount = isBackingToken ? pool.tempus.asset.toBigNum(tokenAmount) : pool.ybt.toBigNum(tokenAmount);
@@ -161,10 +161,10 @@ export class TempusController extends ContractBase {
   async depositAndFix(
     pool: PoolTestFixture,
     user: SignerOrAddress,
-    tokenAmount: NumberOrString,
+    tokenAmount: Numberish,
     isBackingToken: boolean,
-    minTYSRate: NumberOrString,
-    ethValue: NumberOrString = 0,
+    minTYSRate: Numberish,
+    ethValue: Numberish = 0,
     deadline: Date = new Date(8640000000000000) /// default is 9/12/275760 (no deadline)
   ): Promise<Transaction> {
     await this.approve(pool, user, tokenAmount, isBackingToken);
@@ -193,11 +193,11 @@ export class TempusController extends ContractBase {
    async depositAndLeverage(
     pool: PoolTestFixture,
     user: SignerOrAddress,
-    tokenAmount: NumberOrString,
+    tokenAmount: Numberish,
     isBackingToken: boolean,
-    leverageMultiplier: NumberOrString,
-    minCapitalsRate: NumberOrString,
-    ethValue: NumberOrString = 0,
+    leverageMultiplier: Numberish,
+    minCapitalsRate: Numberish,
+    ethValue: Numberish = 0,
     deadline: Date = new Date(8640000000000000) /// default is 9/12/275760 (no deadline)
   ): Promise<Transaction> {
     await this.approve(pool, user, tokenAmount, isBackingToken);
@@ -217,7 +217,7 @@ export class TempusController extends ContractBase {
   async provideLiquidity(
     pool: PoolTestFixture,
     user: SignerOrAddress,
-    sharesAmount: NumberOrString
+    sharesAmount: Numberish
   ): Promise<Transaction> {
     await pool.yields.approve(user, this.address, sharesAmount);
     await pool.principals.approve(user, this.address, sharesAmount);
@@ -227,10 +227,10 @@ export class TempusController extends ContractBase {
   async exitAmmGivenAmountsOutAndEarlyRedeem(
     pool: PoolTestFixture,
     user: SignerOrAddress,
-    principals: NumberOrString,
-    yields: NumberOrString,
-    principalsLp: NumberOrString,
-    yieldsLp: NumberOrString,
+    principals: Numberish,
+    yields: Numberish,
+    principalsLp: Numberish,
+    yieldsLp: Numberish,
     toBackingToken: boolean
   ): Promise<Transaction> {
     const amm = pool.amm, t = pool.tempus;
@@ -252,13 +252,13 @@ export class TempusController extends ContractBase {
   async exitAmmGivenLpAndRedeem(
     pool:PoolTestFixture, 
     user: SignerOrAddress, 
-    lpTokens:NumberOrString, 
-    principals:NumberOrString, 
-    yields:NumberOrString, 
+    lpTokens:Numberish, 
+    principals:Numberish, 
+    yields:Numberish, 
     toBacking: boolean,
-    maxLeftoverShares: NumberOrString,
-    yieldsRate: NumberOrString = 1,
-    maxSlippage: NumberOrString = 1,
+    maxLeftoverShares: Numberish,
+    yieldsRate: Numberish = 1,
+    maxSlippage: Numberish = 1,
     deadline: Date = new Date(8640000000000000) /// default is 9/12/275760 (no deadline)
   ): Promise<Transaction> {
     const amm = pool.amm, t = pool.tempus, addr = addressOf(user);

--- a/test/utils/TempusOTC.ts
+++ b/test/utils/TempusOTC.ts
@@ -1,5 +1,5 @@
 import { Contract, Transaction } from "ethers";
-import { NumberOrString } from "./Decimal";
+import { Numberish } from "./Decimal";
 import { ContractBase, SignerOrAddress, Signer } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 import { getContractAddress } from '@ethersproject/address';
@@ -10,9 +10,9 @@ import { getContractAddress } from '@ethersproject/address';
 export class TempusOTC extends ContractBase {
   tokenToBuy: ERC20;
   tokenToSell: ERC20;
-  sellAmount: NumberOrString;
+  sellAmount: Numberish;
 
-  constructor(contract: Contract, tokenToBuy: ERC20, tokenToSell: ERC20, sellAmount: NumberOrString) {
+  constructor(contract: Contract, tokenToBuy: ERC20, tokenToSell: ERC20, sellAmount: Numberish) {
     super("TempusOTC", 18, contract);
 
     this.tokenToBuy = tokenToBuy;
@@ -24,8 +24,8 @@ export class TempusOTC extends ContractBase {
     owner: Signer,
     tokenToBuy: ERC20,
     tokenToSell: ERC20, 
-    buyAmount: NumberOrString, 
-    sellAmount: NumberOrString, 
+    buyAmount: Numberish, 
+    sellAmount: Numberish, 
     taker: string
   ): Promise<TempusOTC> {
     
@@ -58,7 +58,7 @@ export class TempusOTC extends ContractBase {
    * @param user The caller who is sending this approve
    * @param amount Amount of tokens to approve in contract decimals, eg 2.0 or "0.00001"
    */
-  async approve(token: ERC20, user:SignerOrAddress, amount:NumberOrString) {
+  async approve(token: ERC20, user:SignerOrAddress, amount:Numberish) {
     await token.approve(user, this.address, amount);
   }
   

--- a/test/utils/TempusPool.ts
+++ b/test/utils/TempusPool.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BytesLike, Contract, Transaction } from "ethers";
-import { NumberOrString, toWei, parseDecimal, formatDecimal, MAX_UINT256 } from "./Decimal";
+import { Numberish, toWei, parseDecimal, formatDecimal, MAX_UINT256 } from "./Decimal";
 import { ContractBase, Signer, SignerOrAddress, addressOf } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 import { IERC20 } from "./IERC20";
@@ -23,9 +23,9 @@ export interface TempusSharesNames {
 }
 
 export interface TempusFeesConfig {
-  depositPercent: NumberOrString;
-  earlyRedeemPercent: NumberOrString;
-  matureRedeemPercent: NumberOrString;
+  depositPercent: Numberish;
+  earlyRedeemPercent: Numberish;
+  matureRedeemPercent: Numberish;
 }
 
 export function generateTempusSharesNames(ybtName:string, ybtSymbol:string, maturityTime:number): TempusSharesNames {
@@ -364,18 +364,18 @@ export class TempusPool extends ContractBase {
   /**
    * @returns Number of YBT deposited into this TempusPool contract
    */
-  async contractBalance(): Promise<NumberOrString> {
+  async contractBalance(): Promise<Numberish> {
     return this.yieldBearing.balanceOf(this.contract.address);
   }
 
-  async onDepositYieldBearing(user:SignerOrAddress, yieldBearingAmount:NumberOrString, recipient:SignerOrAddress): Promise<Transaction> {
+  async onDepositYieldBearing(user:SignerOrAddress, yieldBearingAmount:Numberish, recipient:SignerOrAddress): Promise<Transaction> {
     await this.yieldBearing.approve(user, this.contract.address, yieldBearingAmount);
     return this.connect(user).onDepositYieldBearing(
       this.yieldBearing.toBigNum(yieldBearingAmount), addressOf(recipient)
     );
   }
 
-  async onDepositBacking(user:SignerOrAddress, backingTokenAmount:NumberOrString, recipient:SignerOrAddress, ethValue: NumberOrString = 0): Promise<Transaction> {
+  async onDepositBacking(user:SignerOrAddress, backingTokenAmount:Numberish, recipient:SignerOrAddress, ethValue: Numberish = 0): Promise<Transaction> {
     return this.connect(user).onDepositBacking(
       this.asset.toBigNum(backingTokenAmount), addressOf(recipient), { value: toWei(ethValue)}
     );
@@ -389,7 +389,7 @@ export class TempusPool extends ContractBase {
    * @param from Address of which Tempus Shares should be burned
    * @param recipient Address to which redeemed Backing Tokens should be transferred
    */
-  async redeemToBacking(user:SignerOrAddress, principalAmount:NumberOrString, yieldAmount:NumberOrString, from: SignerOrAddress = user, recipient: SignerOrAddress = user): Promise<Transaction> {
+  async redeemToBacking(user:SignerOrAddress, principalAmount:Numberish, yieldAmount:Numberish, from: SignerOrAddress = user, recipient: SignerOrAddress = user): Promise<Transaction> {
     return this.contract.connect(user).redeemToBacking(
       addressOf(from), this.principalShare.toBigNum(principalAmount), this.yieldShare.toBigNum(yieldAmount), addressOf(recipient)
     );
@@ -403,7 +403,7 @@ export class TempusPool extends ContractBase {
    * @param from Address of which Tempus Shares should be burned
    * @param recipient Address to which redeemed Yield Bearing Tokens should be transferred
    */
-  async redeem(user:SignerOrAddress, principalAmount:NumberOrString, yieldAmount:NumberOrString, from: SignerOrAddress = user, recipient: SignerOrAddress = user): Promise<Transaction> {
+  async redeem(user:SignerOrAddress, principalAmount:Numberish, yieldAmount:Numberish, from: SignerOrAddress = user, recipient: SignerOrAddress = user): Promise<Transaction> {
     try {
       return this.contract.connect(user).redeem(
         addressOf(from), this.principalShare.toBigNum(principalAmount), this.yieldShare.toBigNum(yieldAmount), addressOf(recipient)
@@ -442,14 +442,14 @@ export class TempusPool extends ContractBase {
    * @returns The address of the backing token
    *          or the zero address in case of ETH
    */
-  async backingToken(): Promise<NumberOrString> {
+  async backingToken(): Promise<Numberish> {
     return await this.contract.backingToken();
   }
 
   /**
    * @returns The start time of the pool
    */
-  async startTime(): Promise<NumberOrString> {
+  async startTime(): Promise<Numberish> {
     let start:BigNumber = await this.contract.startTime();
     return start.toNumber();
   }
@@ -457,7 +457,7 @@ export class TempusPool extends ContractBase {
   /**
    * @returns The maturity time of the pool
    */
-  async maturityTime(): Promise<NumberOrString> {
+  async maturityTime(): Promise<Numberish> {
     let maturity:BigNumber = await this.contract.maturityTime();
     return maturity.toNumber();
   }
@@ -466,7 +466,7 @@ export class TempusPool extends ContractBase {
    * @returns The exceptional halt time of the pool
    * @note This returns null in case it is not set (i.e. has the special value of `type(uin256).max`)
    */
-  async exceptionalHaltTime(): Promise<NumberOrString | null> {
+  async exceptionalHaltTime(): Promise<Numberish | null> {
     let exceptionalHaltTime:BigNumber = await this.contract.exceptionalHaltTime();
     if (exceptionalHaltTime.toHexString() === MAX_UINT256) {
       return null;
@@ -477,7 +477,7 @@ export class TempusPool extends ContractBase {
   /**
    * @returns The maximum allowed duration of negative yield periods (in seconds)
    */
-  async maximumNegativeYieldDuration(): Promise<NumberOrString> {
+  async maximumNegativeYieldDuration(): Promise<Numberish> {
     let maximumNegativeYieldDuration:BigNumber = await this.contract.maximumNegativeYieldDuration();
     return maximumNegativeYieldDuration.toNumber();
   }
@@ -485,28 +485,28 @@ export class TempusPool extends ContractBase {
   /**
    * @returns JS decimal converted to suitable contract Exchange Rate precision BigNumber
    */
-  public toContractExchangeRate(decimal:NumberOrString): BigNumber {
+  public toContractExchangeRate(decimal:Numberish): BigNumber {
     return parseDecimal(decimal, this.exchangeRatePrec);
   }
 
   /**
    * @returns Initial Interest Rate when the pool started
    */
-  async initialInterestRate(): Promise<NumberOrString> {
+  async initialInterestRate(): Promise<Numberish> {
     return formatDecimal(await this.contract.initialInterestRate(), this.exchangeRatePrec);
   }
 
   /**
    * @returns Current STORED Interest rate of the pool
    */
-  async currentInterestRate(): Promise<NumberOrString> {
+  async currentInterestRate(): Promise<Numberish> {
     return formatDecimal(await this.contract.currentInterestRate(), this.exchangeRatePrec);
   }
 
   /**
    * @returns Updated current Interest Rate
    */
-  async updateInterestRate(): Promise<NumberOrString> {
+  async updateInterestRate(): Promise<Numberish> {
     await this.contract.updateInterestRate();
     return this.currentInterestRate();
   }
@@ -514,7 +514,7 @@ export class TempusPool extends ContractBase {
   /**
    * @returns Interest rate at maturity of the pool
    */
-  async maturityInterestRate(): Promise<NumberOrString> {
+  async maturityInterestRate(): Promise<Numberish> {
     return formatDecimal(await this.contract.maturityInterestRate(), this.exchangeRatePrec);
   }
 
@@ -524,7 +524,7 @@ export class TempusPool extends ContractBase {
    * @return Amount of Principals (TPS) and Yields (TYS) in Principal/YieldShare decimal precision
    *         TPS and TYS are minted in 1:1 ratio, hence a single return value
    */
-  async estimatedMintedShares(amount:NumberOrString, backingToken:boolean): Promise<NumberOrString> {
+  async estimatedMintedShares(amount:Numberish, backingToken:boolean): Promise<Numberish> {
     return this.principalShare.fromBigNum(await this.contract.estimatedMintedShares(amount, backingToken));
   }
 
@@ -534,28 +534,28 @@ export class TempusPool extends ContractBase {
    * @return Amount of Principals (TPS) and Yields (TYS), scaled as 1e18 decimals.
    *         TPS and TYS are redeemed in 1:1 ratio before maturity, hence a single return value.
    */
-  async getSharesAmountForExactTokensOut(amountOut:NumberOrString, isBackingToken:boolean): Promise<NumberOrString> {
+  async getSharesAmountForExactTokensOut(amountOut:Numberish, isBackingToken:boolean): Promise<Numberish> {
     const numTokensOut = isBackingToken ? this.asset.toBigNum(amountOut) : this.yieldBearing.toBigNum(amountOut);
     return this.principalShare.fromBigNum(await this.contract.getSharesAmountForExactTokensOut(numTokensOut, isBackingToken));
   }
   
-  async numAssetsPerYieldToken(amount:NumberOrString, interestRate:NumberOrString): Promise<NumberOrString> {
+  async numAssetsPerYieldToken(amount:Numberish, interestRate:Numberish): Promise<Numberish> {
     return this.asset.fromBigNum(await this.contract.numAssetsPerYieldToken(
       this.yieldBearing.toBigNum(amount), this.toContractExchangeRate(interestRate)
     ));
   }
 
-  async numYieldTokensPerAsset(amount:NumberOrString, interestRate:NumberOrString): Promise<NumberOrString> {
+  async numYieldTokensPerAsset(amount:Numberish, interestRate:Numberish): Promise<Numberish> {
     return this.yieldBearing.fromBigNum(await this.contract.numYieldTokensPerAsset(
       this.asset.toBigNum(amount), this.toContractExchangeRate(interestRate)
     ));
   }
 
-  async pricePerPrincipalShare(): Promise<NumberOrString> {
+  async pricePerPrincipalShare(): Promise<Numberish> {
     return this.principalShare.fromBigNum(await this.contract.pricePerPrincipalShareStored());
   }
 
-  async pricePerYieldShare(): Promise<NumberOrString> {
+  async pricePerYieldShare(): Promise<Numberish> {
     return this.yieldShare.fromBigNum(await this.contract.pricePerYieldShareStored());
   }
 
@@ -563,7 +563,7 @@ export class TempusPool extends ContractBase {
   /**
    * @returns Total accumulated fees
    */
-  async totalFees(): Promise<NumberOrString> {
+  async totalFees(): Promise<Numberish> {
     return this.yieldBearing.fromBigNum(await this.contract.totalFees());
   }
 

--- a/test/utils/TempusPoolAMM.ts
+++ b/test/utils/TempusPoolAMM.ts
@@ -1,5 +1,5 @@
 import { Contract } from "ethers";
-import { NumberOrString, toWei } from "./Decimal";
+import { Numberish, toWei } from "./Decimal";
 import { ContractBase, Signer } from "./ContractBase";
 import { AMP_PRECISION, TempusAMM } from "./TempusAMM";
 import { PoolShare } from "./PoolShare";
@@ -51,16 +51,16 @@ export class TempusPoolAMM extends TempusAMM {
     return new TempusPoolAMM(tempusAMM, principalShare, yieldShare);
   }
 
-  async getExpectedPYOutGivenLPIn(inAmount: NumberOrString): Promise<{principalsOut:number, yieldsOut:number}> {
+  async getExpectedPYOutGivenLPIn(inAmount: Numberish): Promise<{principalsOut:number, yieldsOut:number}> {
     const p = await super.getTokensOutGivenLPIn(inAmount);
     return {principalsOut: +p.token0Out, yieldsOut: +p.token1Out};
   }
 
-  async getLPTokensOutForTokensIn(principalsAmountIn:NumberOrString, yieldsAmountIn:NumberOrString): Promise<NumberOrString> {
+  async getLPTokensOutForTokensIn(principalsAmountIn:Numberish, yieldsAmountIn:Numberish): Promise<Numberish> {
     return super.getLPTokensOutForTokensIn(principalsAmountIn, yieldsAmountIn);
   }
 
-  async getLPTokensInGivenTokensOut(principalStaked:NumberOrString, yieldsStaked:NumberOrString): Promise<NumberOrString> {
+  async getLPTokensInGivenTokensOut(principalStaked:Numberish, yieldsStaked:Numberish): Promise<Numberish> {
     return super.getLPTokensInGivenTokensOut(principalStaked, yieldsStaked);
   }
 

--- a/test/utils/TempusToken.ts
+++ b/test/utils/TempusToken.ts
@@ -1,4 +1,4 @@
-import { NumberOrString } from "./Decimal";
+import { Numberish } from "./Decimal";
 import { SignerOrAddress, addressOf } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 import { Signer } from "crypto";
@@ -17,7 +17,7 @@ export class TempusToken extends ERC20 {
    * @param sender Account that is issuing the burn.
    * @param amount Number of tokens to burn
    */
-  async burn(sender:SignerOrAddress, amount:NumberOrString): Promise<void> {
+  async burn(sender:SignerOrAddress, amount:Numberish): Promise<void> {
     await this.connect(sender).burn(this.toBigNum(amount));
   }
 
@@ -27,7 +27,7 @@ export class TempusToken extends ERC20 {
    * @param account Account to which we issue tokens
    * @param amount Number of tokens to mint
    */
-  async mint(sender:SignerOrAddress, account:SignerOrAddress, amount:NumberOrString): Promise<Transaction> {
+  async mint(sender:SignerOrAddress, account:SignerOrAddress, amount:Numberish): Promise<Transaction> {
     return this.connect(sender).mint(addressOf(account), this.toBigNum(amount));
   }
 
@@ -49,11 +49,11 @@ export class TempusToken extends ERC20 {
     return this.contract.MIN_TIME_BETWEEN_MINTS();
   }
 
-  async INITIAL_SUPPLY(): Promise<NumberOrString> {
+  async INITIAL_SUPPLY(): Promise<Numberish> {
     return this.contract.INITIAL_SUPPLY();
   }
 
-  async MINT_CAP(): Promise<NumberOrString> {
+  async MINT_CAP(): Promise<Numberish> {
     return this.contract.MINT_CAP();
   }
 }

--- a/test/utils/YearnVault.ts
+++ b/test/utils/YearnVault.ts
@@ -1,5 +1,5 @@
 import { Contract } from "ethers";
-import { formatDecimal, NumberOrString, parseDecimal } from "./Decimal";
+import { formatDecimal, Numberish, parseDecimal } from "./Decimal";
 import { ContractBase, SignerOrAddress } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 import { TokenInfo } from "test/pool-utils/TokenInfo";
@@ -29,14 +29,14 @@ export class YearnVault extends ContractBase {
   /**
    * @return Current price per share
    */
-  async pricePerShare(): Promise<NumberOrString> {
+  async pricePerShare(): Promise<Numberish> {
     return formatDecimal(await this.contract.pricePerShare(), this.yieldToken.decimals);
   }
 
   /**
    * Sets the pool price per share
    */
-  async setPricePerShare(pricePerShare:NumberOrString, owner:SignerOrAddress = null): Promise<void> {
+  async setPricePerShare(pricePerShare:Numberish, owner:SignerOrAddress = null): Promise<void> {
     if (owner !== null) {
       const prevExchangeRate = await this.pricePerShare();
       const difference = (Number(pricePerShare) / Number(prevExchangeRate)) - 1;
@@ -49,12 +49,12 @@ export class YearnVault extends ContractBase {
     await this.contract.setPricePerShare(parseDecimal(pricePerShare.toString(), this.yieldToken.decimals));
   }
 
-  async deposit(user:SignerOrAddress, amount:NumberOrString): Promise<void> {
+  async deposit(user:SignerOrAddress, amount:Numberish): Promise<void> {
     await this.asset.approve(user, this.address, amount);
     await this.contract.connect(user).deposit(this.asset.toBigNum(amount));
   }
 
-  async withdraw(user:SignerOrAddress, maxShares:NumberOrString, recipient: SignerOrAddress): Promise<void> {
+  async withdraw(user:SignerOrAddress, maxShares:Numberish, recipient: SignerOrAddress): Promise<void> {
     await this.contract.connect(user).deposit(this.yieldToken.toBigNum(maxShares), recipient);
   }
 }


### PR DESCRIPTION
And that's about it.

We can discuss here if some other name would be more suitable, eg `Numberish`?

The plan is to do something like this next:
```
export type Numberish = Number | string | BigNumber;
```
Which is a very simple change without current side-effects, but will make possible to send BigNumbers directly to the contract if needed.