### PR TITLE
refactor: improve ERC20 utilities and interoperability with Decimal

### DIFF
--- a/test/Decimal.test.ts
+++ b/test/Decimal.test.ts
@@ -90,6 +90,14 @@ describeNonPool("Decimal", () =>
       equals(dec18('100.12345678901234567890').toNumber(), '100.12345678901235');
     });
 
+    it("chai equality tests", () =>
+    {
+      expect(dec18('100.123456')).to.eql(dec18('100.123456'));
+      expect(dec18('100.123456')).to.not.equal(dec18('100.123456'));
+      expect(+dec18('100.123456')).to.equal(100.123456);
+      expect(dec18('100.123456')).to.not.equal(100.123456);
+    });
+
     type BinaryOp<T> = (a:number, b:number) => T;
 
     // toFixed, but with BigNumber-like rounding

--- a/test/utils/Decimal.ts
+++ b/test/utils/Decimal.ts
@@ -91,6 +91,25 @@ export class Decimal {
     return Number(this.toString());
   }
 
+  /**
+   * @brief To compare if two Decimals are equal.
+   *        For chai asserts use deep equality
+   *        Ex: expect(a).to.eql(b);  -- chai deep equality check
+   *        Ex: expect(a.equals(b)).to.be.true;  -- directly call equals
+   */
+  public equals(other:Decimal): boolean {
+    return this.decimals === other.decimals && this.int === other.int;
+  }
+
+  /**
+   * @brief To enable quick conversion from Decimal to a number
+   *        Ex: let x:string = +myDecimal;
+   *        Ex: expect(+myDecimal).to.equal(100);
+   */
+  public valueOf(): number {
+    return this.toNumber();
+  }
+
   private static readonly ONE_CACHE: { [key:number]: bigint } = {
     6: BigInt("1000000"),
     18: BigInt("1000000000000000000"),
@@ -329,5 +348,10 @@ export class DecimalConvertible {
   /** @return Converts a BN big decimal of this Contract into a String or Number */
   public fromBigNum(contractDecimal:BigNumber): Numberish {
     return formatDecimal(contractDecimal, this.decimals);
+  }
+
+  /** @return Converts a BN big decimal of this Contract into a Decimal with this contract's decimals precision */
+  public toDecimal(contractDecimal:BigNumber): Decimal {
+    return new Decimal(contractDecimal, this.decimals);
   }
 }

--- a/test/utils/ERC20Ether.ts
+++ b/test/utils/ERC20Ether.ts
@@ -1,6 +1,6 @@
 import { ethers } from "hardhat";
 import { Numberish, DecimalConvertible } from "./Decimal";
-import { SignerOrAddress, Signer, addressOf } from "./ContractBase";
+import { Signer, Addressable, addressOf } from "./ContractBase";
 import { IERC20 } from "./IERC20";
 
 /**
@@ -30,7 +30,7 @@ export class ERC20Ether extends DecimalConvertible implements IERC20 {
    * @param account ERC20 account's address
    * @returns Balance of ERC20 address in decimals, eg 2.0
    */
-  async balanceOf(account:SignerOrAddress): Promise<Numberish> {
+  async balanceOf(account:Addressable): Promise<Numberish> {
     const balance = await ethers.provider.getBalance(addressOf(account));
     return this.fromBigNum(balance);
   }
@@ -41,7 +41,7 @@ export class ERC20Ether extends DecimalConvertible implements IERC20 {
    * @param recipient ERC20 transfer recipient's address
    * @param amount Amount of tokens to send in contract decimals, eg 2.0 or "0.00001"
    */
-  async transfer(sender:SignerOrAddress, recipient:SignerOrAddress, amount:Numberish): Promise<any> {
+  async transfer(sender:Addressable, recipient:Addressable, amount:Numberish): Promise<any> {
     const signer = <Signer>sender;
     return signer.sendTransaction({
       from: signer.address,
@@ -56,7 +56,7 @@ export class ERC20Ether extends DecimalConvertible implements IERC20 {
    * @returns The remaining number of tokens that `spender` will be allowed to 
    * spend on behalf of `owner` through {transferFrom}. This is zero by default.
    */
-  async allowance(owner:SignerOrAddress, spender:SignerOrAddress): Promise<Numberish> {
+  async allowance(owner:Addressable, spender:Addressable): Promise<Numberish> {
     return 0;
   }
   
@@ -66,7 +66,7 @@ export class ERC20Ether extends DecimalConvertible implements IERC20 {
    * @param spender ERC20 approve's, spender's address
    * @param amount Amount of tokens to approve in contract decimals, eg 2.0 or "0.00001"
    */
-  async approve(caller:SignerOrAddress, spender:SignerOrAddress, amount:Numberish): Promise<any> {
+  async approve(caller:Addressable, spender:Addressable, amount:Numberish): Promise<any> {
     return;
   }
 
@@ -77,7 +77,7 @@ export class ERC20Ether extends DecimalConvertible implements IERC20 {
    * @param recipient ERC20 transferFrom recipient's address
    * @param amount Amount of tokens to send in contract decimals, eg 2.0 or "0.00001"
    */
-  async transferFrom(sender:SignerOrAddress, recipient:SignerOrAddress, amount:Numberish): Promise<any> {
+  async transferFrom(sender:Addressable, recipient:Addressable, amount:Numberish): Promise<any> {
     return this.transfer(sender, recipient, amount);
   }
 }

--- a/test/utils/IERC20.ts
+++ b/test/utils/IERC20.ts
@@ -1,5 +1,5 @@
 import { Numberish } from "./Decimal";
-import { SignerOrAddress } from "./ContractBase";
+import { Addressable } from "./ContractBase";
 import { BigNumber } from "@ethersproject/bignumber";
 
 /**
@@ -22,7 +22,7 @@ export interface IERC20 {
    * @param account ERC20 account's address
    * @returns Balance of ERC20 address in decimals, eg 2.0
    */
-  balanceOf(account:SignerOrAddress): Promise<Numberish>;
+  balanceOf(account:Addressable): Promise<Numberish>;
 
   /**
    * @dev Moves `amount` tokens from the sender's account to `recipient`.
@@ -30,7 +30,7 @@ export interface IERC20 {
    * @param recipient ERC20 transfer recipient's address
    * @param amount Amount of tokens to send in contract decimals, eg 2.0 or "0.00001"
    */
-  transfer(sender:SignerOrAddress, recipient:SignerOrAddress, amount:Numberish): Promise<any>;
+  transfer(sender:Addressable, recipient:Addressable, amount:Numberish): Promise<any>;
 
   /**
    * @param owner ERC20 owner's address
@@ -38,7 +38,7 @@ export interface IERC20 {
    * @returns The remaining number of tokens that `spender` will be allowed to 
    * spend on behalf of `owner` through {transferFrom}. This is zero by default.
    */
-  allowance(owner:SignerOrAddress, spender:SignerOrAddress): Promise<Numberish>;
+  allowance(owner:Addressable, spender:Addressable): Promise<Numberish>;
 
   /**
    * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
@@ -46,7 +46,7 @@ export interface IERC20 {
    * @param spender ERC20 approve's, spender's address
    * @param amount Amount of tokens to approve in contract decimals, eg 2.0 or "0.00001"
    */
-  approve(caller:SignerOrAddress, spender:SignerOrAddress, amount:Numberish): Promise<any>;
+  approve(caller:Addressable, spender:Addressable, amount:Numberish): Promise<any>;
 
   /**
    * @dev Moves `amount` tokens from `sender` to `recipient` using the
@@ -55,7 +55,7 @@ export interface IERC20 {
    * @param recipient ERC20 transferFrom recipient's address
    * @param amount Amount of tokens to send in contract decimals, eg 2.0 or "0.00001"
    */
-  transferFrom(sender:SignerOrAddress, recipient:SignerOrAddress, amount:Numberish): Promise<any>;
+  transferFrom(sender:Addressable, recipient:Addressable, amount:Numberish): Promise<any>;
 
   /** @return Converts a Number or String into this Contract's BigNumber decimal */
   toBigNum(amount:Numberish): BigNumber;


### PR DESCRIPTION
Main goal is to make ERC20 utility much easier to use.
Calling `this.toDecimal(await this.contract.getBalance())` allows for a quick conversion to `Decimal`
Also added `Decimal.valueOf()` and `Decimal.equals()` to make integration into unit tests easier.

Refactored ERC20 decimals initialization to have less awaits.

Finally, added new `Addressable` to make it possible to call `token.balanceOf(tempusPool)` and similar functions with any kind of addressable object. Such as ethers.Contract, ethers.SignerWithAddress, string and our ContractBase.