### PR TITLE
refactor: use `Decimal` as the return type for `ERC20.balanceOf()`

### DIFF
--- a/test/TempusController.test.ts
+++ b/test/TempusController.test.ts
@@ -268,10 +268,10 @@ describeForEachPool("TempusController", (testPool:PoolTestFixture) =>
         9999 - userYRedeem,
         false
       );
-      expect(await pool.yieldShare.balanceOf(user2)).to.equal(0);
-      expect(await pool.principalShare.balanceOf(user2)).to.equal(0);
+      expect(+await pool.yieldShare.balanceOf(user2)).to.equal(0);
+      expect(+await pool.principalShare.balanceOf(user2)).to.equal(0);
       expect(+await amm.balanceOf(user2)).to.be.within(0.991, 0.993);
-      expect(await pool.yieldBearing.balanceOf(user2)).to.equal(99999);
+      expect(+await pool.yieldBearing.balanceOf(user2)).to.equal(99999);
     });
 
     it("Exit AMM and redeem to backing before maturity", async () => 
@@ -297,10 +297,10 @@ describeForEachPool("TempusController", (testPool:PoolTestFixture) =>
       }
       else {
         await reedemAction;
-        expect(await pool.yieldShare.balanceOf(user2)).to.equal(0);
-        expect(await pool.principalShare.balanceOf(user2)).to.equal(0);
+        expect(+await pool.yieldShare.balanceOf(user2)).to.equal(0);
+        expect(+await pool.principalShare.balanceOf(user2)).to.equal(0);
         expect(+await amm.balanceOf(user2)).to.be.within(0.991, 0.993);
-        expect(await testPool.asset.balanceOf(user2)).to.equal(109999);
+        expect(+await testPool.asset.balanceOf(user2)).to.equal(109999);
       }
     });
 
@@ -511,8 +511,8 @@ describeForEachPool("TempusController", (testPool:PoolTestFixture) =>
     it("Complete exit to yield bearing", async () => 
     {
       await initAMM(user1, /*ybtDeposit*/1000000, /*principals*/100000, /*yields*/1000000);
-      expect(await testPool.yields.balanceOf(user1)).to.equal(0, "all yields are in amm");
-      expect(await testPool.principals.balanceOf(user1)).to.equal(
+      expect(+await testPool.yields.balanceOf(user1)).to.equal(0, "all yields are in amm");
+      expect(+await testPool.principals.balanceOf(user1)).to.equal(
         900000, 
         "balance should decrease as there is some of it locked in amm"
       );
@@ -521,7 +521,7 @@ describeForEachPool("TempusController", (testPool:PoolTestFixture) =>
       await testPool.setInterestRate(1.1);
       await testPool.fastForwardToMaturity();
 
-      expect(await testPool.ybt.balanceOf(user1)).to.equal(0);
+      expect(+await testPool.ybt.balanceOf(user1)).to.equal(0);
 
       await controller.exitAmmGivenLpAndRedeem(
         testPool, 
@@ -533,9 +533,9 @@ describeForEachPool("TempusController", (testPool:PoolTestFixture) =>
         getDefaultLeftoverShares()
       );
 
-      expect(await testPool.yields.balanceOf(user1)).to.equal(0);
-      expect(await testPool.principals.balanceOf(user1)).to.equal(0);
-      expect(await testPool.amm.contract.balanceOf(user1.address)).to.equal(0);
+      expect(+await testPool.yields.balanceOf(user1)).to.equal(0);
+      expect(+await testPool.principals.balanceOf(user1)).to.equal(0);
+      expect(+await testPool.amm.contract.balanceOf(user1.address)).to.equal(0);
       if (testPool.yieldPeggedToAsset) {
         expect(+await testPool.ybt.balanceOf(user1)).to.be.within(1099000, 1101000);
       } else {
@@ -547,8 +547,8 @@ describeForEachPool("TempusController", (testPool:PoolTestFixture) =>
     it("Complete exit to backing", async () => 
     {
       await initAMM(user1, /*ybtDeposit*/1000000, /*principals*/100000, /*yields*/1000000);
-      expect(await pool.yieldShare.balanceOf(user1)).to.equal(0, "all yields are in amm");
-      expect(await pool.principalShare.balanceOf(user1)).to.equal(
+      expect(+await pool.yieldShare.balanceOf(user1)).to.equal(0, "all yields are in amm");
+      expect(+await pool.principalShare.balanceOf(user1)).to.equal(
         900000,
         "balance should decrease as there is some of it locked in amm"
       );
@@ -573,7 +573,7 @@ describeForEachPool("TempusController", (testPool:PoolTestFixture) =>
       }
       else
       {
-        expect(await testPool.asset.balanceOf(user1)).to.equal(100000);
+        expect(+await testPool.asset.balanceOf(user1)).to.equal(100000);
         await controller.exitAmmGivenLpAndRedeem(
           testPool, 
           user1, 
@@ -583,9 +583,9 @@ describeForEachPool("TempusController", (testPool:PoolTestFixture) =>
           true,
           getDefaultLeftoverShares()
         );
-        expect(await pool.yieldShare.balanceOf(user1)).to.equal(0);
-        expect(await pool.principalShare.balanceOf(user1)).to.equal(0);
-        expect(await testPool.amm.contract.balanceOf(user1.address)).to.equal(0);
+        expect(+await pool.yieldShare.balanceOf(user1)).to.equal(0);
+        expect(+await pool.principalShare.balanceOf(user1)).to.equal(0);
+        expect(+await testPool.amm.contract.balanceOf(user1.address)).to.equal(0);
         expect(+await testPool.asset.balanceOf(user1)).to.be.within(1199000, 1200000);
       }
     });

--- a/test/TempusPool.Deploy.test.ts
+++ b/test/TempusPool.Deploy.test.ts
@@ -48,14 +48,14 @@ describeForEachPool("TempusPool Deploy", (testPool:PoolTestFixture) =>
 
   it("Principal shares initial details", async () =>
   {
-    expect(await pool.principalShare.totalSupply()).to.equal(0);
+    expect(+await pool.principalShare.totalSupply()).to.equal(0);
     expect(await pool.principalShare.name()).to.equal(testPool.names.principalName);
     expect(await pool.principalShare.symbol()).to.equal(testPool.names.principalSymbol);
   });
 
   it("Yield shares initial details", async () =>
   {
-    expect(await pool.yieldShare.totalSupply()).to.equal(0);
+    expect(+await pool.yieldShare.totalSupply()).to.equal(0);
     expect(await pool.yieldShare.name()).to.equal(testPool.names.yieldName);
     expect(await pool.yieldShare.symbol()).to.equal(testPool.names.yieldSymbol);
   });
@@ -64,8 +64,8 @@ describeForEachPool("TempusPool Deploy", (testPool:PoolTestFixture) =>
   {
     let [owner] = testPool.signers;
     await pool.transferFees(owner, owner);
-    expect(await pool.yieldBearing.balanceOf(owner)).to.equal(0);
-    expect(await pool.totalFees()).to.equal(0);
+    expect(+await pool.yieldBearing.balanceOf(owner)).to.equal(0);
+    expect(+await pool.totalFees()).to.equal(0);
   });
 
   it("Should revert if maturity is less than current time", async () =>

--- a/test/TempusPool.Fees.test.ts
+++ b/test/TempusPool.Fees.test.ts
@@ -54,10 +54,10 @@ describeForEachPool("TempusPool Fees", (pool:PoolTestFixture) =>
 
     await pool.tempus.setFeesConfig(owner, { depositPercent: 0.01, earlyRedeemPercent: 0.0, matureRedeemPercent: 0.0 });
     await pool.depositYBT(user, 100);
-    expect(await pool.tempus.contractBalance()).to.equal(100); // all 100 in the pool
+    expect(+await pool.tempus.contractBalance()).to.equal(100); // all 100 in the pool
     // but user receives 99
     (await pool.userState(user)).expect(99, 99, /*yieldBearing:*/400);
-    expect(await pool.tempus.totalFees()).to.equal(1); // and 1 as accumulated fees
+    expect(+await pool.tempus.totalFees()).to.equal(1); // and 1 as accumulated fees
   });
 
   it("Should collect tokens as fees during EARLY redeem() if fees != 0", async () =>
@@ -66,12 +66,12 @@ describeForEachPool("TempusPool Fees", (pool:PoolTestFixture) =>
 
     await pool.tempus.setFeesConfig(owner, { depositPercent: 0.0, earlyRedeemPercent: 0.01, matureRedeemPercent: 0.0 });
     await pool.depositYBT(user, 100);
-    expect(await pool.tempus.contractBalance()).to.equal(100); // all 100 in the pool
+    expect(+await pool.tempus.contractBalance()).to.equal(100); // all 100 in the pool
     (await pool.userState(user)).expect(100, 100, /*yieldBearing:*/400);
 
     await pool.redeemToYBT(user, 100, 100);
-    expect(await pool.tempus.totalFees()).to.equal(1); // and 1 as accumulated fees
-    expect(await pool.tempus.contractBalance()).to.equal(1); // should have 1 in the pool (this is the fees)
+    expect(+await pool.tempus.totalFees()).to.equal(1); // and 1 as accumulated fees
+    expect(+await pool.tempus.contractBalance()).to.equal(1); // should have 1 in the pool (this is the fees)
     (await pool.userState(user)).expect(0, 0, /*yieldBearing:*/499); // receive 99 back
   });
 
@@ -81,15 +81,15 @@ describeForEachPool("TempusPool Fees", (pool:PoolTestFixture) =>
 
     await pool.tempus.setFeesConfig(owner, { depositPercent: 0.0, earlyRedeemPercent: 0.0, matureRedeemPercent: 0.02 });
     await pool.depositYBT(user, 100);
-    expect(await pool.tempus.contractBalance()).to.equal(100); // all 100 in the pool
+    expect(+await pool.tempus.contractBalance()).to.equal(100); // all 100 in the pool
     (await pool.userState(user)).expect(100, 100, /*yieldBearing:*/400);
 
     await pool.fastForwardToMaturity();
     expect(await pool.tempus.matured()).to.be.true;
 
     await pool.redeemToYBT(user, 100, 100);
-    expect(await pool.tempus.totalFees()).to.equal(2); // 2 as accumulated fees
-    expect(await pool.tempus.contractBalance()).to.equal(2); // should have 2 in the pool (this is the fees)
+    expect(+await pool.tempus.totalFees()).to.equal(2); // 2 as accumulated fees
+    expect(+await pool.tempus.contractBalance()).to.equal(2); // should have 2 in the pool (this is the fees)
     (await pool.userState(user)).expect(0, 0, /*yieldBearing:*/498); // receive 98 back
   });
 
@@ -98,7 +98,7 @@ describeForEachPool("TempusPool Fees", (pool:PoolTestFixture) =>
     await pool.setupAccounts(owner, [[user, 500]]);
 
     await pool.depositYBT(user, 100);
-    expect(await pool.tempus.contractBalance()).to.equal(100); // all 100 in the pool
+    expect(+await pool.tempus.contractBalance()).to.equal(100); // all 100 in the pool
     (await pool.userState(user)).expect(100, 100, /*yieldBearing:*/400);
 
     await pool.fastForwardToMaturity();
@@ -119,7 +119,7 @@ describeForEachPool("TempusPool Fees", (pool:PoolTestFixture) =>
     
     await pool.depositYBT(user, 100);
     
-    expect(await pool.tempus.contractBalance()).to.equal(100); // all 100 in the pool
+    expect(+await pool.tempus.contractBalance()).to.equal(100); // all 100 in the pool
     (await pool.userState(user)).expect(100, 100, /*yieldBearing:*/400);
 
     await pool.fastForwardToMaturity();
@@ -139,13 +139,13 @@ describeForEachPool("TempusPool Fees", (pool:PoolTestFixture) =>
 
     await pool.tempus.setFeesConfig(owner, { depositPercent: 0.10, earlyRedeemPercent: 0.0, matureRedeemPercent: 0.0 });
     await pool.depositYBT(user, 100, /*recipient:*/user);
-    expect(await pool.tempus.contractBalance()).to.equal(100);
+    expect(+await pool.tempus.contractBalance()).to.equal(100);
 
     (await pool.userState(user)).expect(90, 90, /*yieldBearing:*/400);
-    expect(await pool.tempus.totalFees()).to.equal(10);
+    expect(+await pool.tempus.totalFees()).to.equal(10);
 
     await pool.tempus.transferFees(owner, user2);
-    expect(await pool.ybt.balanceOf(user2)).to.equal(10);
-    expect(await pool.tempus.totalFees()).to.equal(0);
+    expect(+await pool.ybt.balanceOf(user2)).to.equal(10);
+    expect(+await pool.tempus.totalFees()).to.equal(0);
   });
 });

--- a/test/TempusPool.Redeem.test.ts
+++ b/test/TempusPool.Redeem.test.ts
@@ -277,7 +277,7 @@ describeForEachPool("TempusPool Redeem", (pool:PoolTestFixture) =>
     await redeem(user, { amount:{tps:100, tys:100}, pegged:{tps:0, tys:0, ybt:600}, unpegged:{tps:0, tys:0, ybt:150} }, "redeem 100+100 after maturity at rate 4.0");
 
     const expectedRemainingPoolYBT = pool.yieldPeggedToAsset ? 200 : 50;
-    expect(await pool.ybt.balanceOf(pool.tempus.address)).to.equal(expectedRemainingPoolYBT);
+    expect(+await pool.ybt.balanceOf(pool.tempus.address)).to.equal(expectedRemainingPoolYBT);
   });
 
   it.includeIntegration("Should redeem correct amount of tokens with multiple users depositing", async () =>

--- a/test/TempusPool.RedeemBackingTokens.test.ts
+++ b/test/TempusPool.RedeemBackingTokens.test.ts
@@ -18,10 +18,10 @@ describeForEachPool.except("TempusPool Redeem", [PoolType.Lido], (pool:PoolTestF
 
     await pool.asset.approve(user, pool.tempus.controller.address, 100);
     await depositBT(user, {btAmount:100, pegged:{tps:100, tys:100, ybt:0}, unpegged:{tps:100, tys:100, ybt:0}}, "0 YBT because we did BT deposit");
-    expect(await pool.asset.balanceOf(user)).to.equal(900);
+    expect(+await pool.asset.balanceOf(user)).to.equal(900);
 
     await redeemBT(user, {amount:{tps:100, tys:100}, pegged:{tps:0, tys:0, ybt:0}, unpegged:{tps:0, tys:0, ybt:0}}, "0 YBT because we did BT redeem");
-    expect(await pool.asset.balanceOf(user)).to.equal(1000, "user must receive all of their BT back");
+    expect(+await pool.asset.balanceOf(user)).to.equal(1000, "user must receive all of their BT back");
   });
 
   it("Should redeem more BackingTokens after changing rate to 2.0", async () =>
@@ -41,7 +41,7 @@ describeForEachPool.except("TempusPool Redeem", [PoolType.Lido], (pool:PoolTestF
     (await pool.depositBT(owner, 200));
 
     await redeemBT(user, {amount:{tps:100, tys:100}, pegged:{tps:0, tys:0, ybt:0}, unpegged:{tps:0, tys:0, ybt:0}}, "0 YBT because we did BT redeem");
-    expect(await pool.asset.balanceOf(user)).to.equal(1100, "gain extra 100 backing tokens due to interest 2.0x");
+    expect(+await pool.asset.balanceOf(user)).to.equal(1100, "gain extra 100 backing tokens due to interest 2.0x");
   });
 });
 

--- a/test/mocks/aave/AavePoolMock.test.ts
+++ b/test/mocks/aave/AavePoolMock.test.ts
@@ -26,8 +26,8 @@ describeForEachPool.type("AAVE Mock", [PoolType.Aave], async (testPool:PoolTestF
       expect(await pool.liquidityIndex()).to.equal(1.0);
       await pool.deposit(user, 4);
       
-      expect(await pool.assetBalance(user)).to.equal(6);
-      expect(await pool.yieldBalance(user)).to.equal(4);
+      expect(+await pool.assetBalance(user)).to.equal(6);
+      expect(+await pool.yieldBalance(user)).to.equal(4);
     });
 
     it("Should receive 0.5x yield tokens if rate is 2.0", async () =>
@@ -37,8 +37,8 @@ describeForEachPool.type("AAVE Mock", [PoolType.Aave], async (testPool:PoolTestF
 
       // with 2.0 rate, user deposits 4 asset tokens and receives 2 yield tokens
       await pool.deposit(user, 4);
-      expect(await pool.assetBalance(user)).to.equal(6);
-      expect(await pool.yieldBalance(user)).to.equal(4);
+      expect(+await pool.assetBalance(user)).to.equal(6);
+      expect(+await pool.yieldBalance(user)).to.equal(4);
     });
 
     it("Should receive same amount of yield tokens if rate is 0.5", async () =>
@@ -47,21 +47,21 @@ describeForEachPool.type("AAVE Mock", [PoolType.Aave], async (testPool:PoolTestF
       expect(await pool.liquidityIndex()).to.equal(0.5);
 
       await pool.deposit(user, 4);
-      expect(await pool.assetBalance(user)).to.equal(6);
-      expect(await pool.yieldBalance(user)).to.equal(4);
+      expect(+await pool.assetBalance(user)).to.equal(6);
+      expect(+await pool.yieldBalance(user)).to.equal(4);
     });
 
     it("Should receive same amount of yield tokens if rate changes", async () =>
     {
       // with 1.0 rate, user deposits 4 assets and receives 4 yield tokens
       await pool.deposit(user, 4);
-      expect(await pool.yieldBalance(user)).to.equal(4);
+      expect(+await pool.yieldBalance(user)).to.equal(4);
       
       // with 2.0 rate, user deposits 4 asset tokens and receives 4 yield tokens
       await pool.setLiquidityIndex(2.0, owner);
-      expect(await pool.yieldBalance(user)).to.equal(8);
+      expect(+await pool.yieldBalance(user)).to.equal(8);
       await pool.deposit(user, 4);
-      expect(await pool.yieldBalance(user)).to.equal(12);
+      expect(+await pool.yieldBalance(user)).to.equal(12);
     });
   });
 });

--- a/test/mocks/compound/ComptrollerMock.test.ts
+++ b/test/mocks/compound/ComptrollerMock.test.ts
@@ -31,8 +31,8 @@ describeForEachPool.type("Compound Mock", [PoolType.Compound], async (testPool:P
       expect(await pool.isParticipant(user)).to.be.true;
       await pool.mint(user, 4);
 
-      expect(await pool.assetBalance(user)).to.equal(6);
-      expect(await pool.yieldBalance(user)).to.equal(200);
+      expect(+await pool.assetBalance(user)).to.equal(6);
+      expect(+await pool.yieldBalance(user)).to.equal(200);
     });
 
     it("Should receive 0.5x yield tokens if rate is 0.04", async () =>
@@ -44,8 +44,8 @@ describeForEachPool.type("Compound Mock", [PoolType.Compound], async (testPool:P
       await pool.enterMarkets(user);
       await pool.mint(user, 4);
 
-      expect(await pool.assetBalance(user)).to.equal(6);
-      expect(await pool.yieldBalance(user)).to.equal(100);
+      expect(+await pool.assetBalance(user)).to.equal(6);
+      expect(+await pool.yieldBalance(user)).to.equal(100);
     });
 
     it("Should receive 2.0x yield tokens if rate is 0.01", async () =>
@@ -57,8 +57,8 @@ describeForEachPool.type("Compound Mock", [PoolType.Compound], async (testPool:P
       await pool.enterMarkets(user);
       await pool.mint(user, 4);
 
-      expect(await pool.assetBalance(user)).to.equal(6);
-      expect(await pool.yieldBalance(user)).to.equal(400);
+      expect(+await pool.assetBalance(user)).to.equal(6);
+      expect(+await pool.yieldBalance(user)).to.equal(400);
     });
 
     it("Should receive different amount of yield tokens if rate changes", async () =>
@@ -66,12 +66,12 @@ describeForEachPool.type("Compound Mock", [PoolType.Compound], async (testPool:P
       // with default 0.02 rate, user deposits 4 assets and receives 4/0.02=200 yield tokens
       await pool.enterMarkets(user);
       await pool.mint(user, 4);
-      expect(await pool.yieldBalance(user)).to.equal(200);
+      expect(+await pool.yieldBalance(user)).to.equal(200);
       
       // with 0.04 rate, user deposits 4 asset tokens and receives 4/0.04=100 yield tokens
       await pool.setExchangeRate(0.04);
       await pool.mint(user, 4);
-      expect(await pool.yieldBalance(user)).to.equal(200 + 100);
+      expect(+await pool.yieldBalance(user)).to.equal(200 + 100);
     });
     
     it("Should be non-participant after exitMarket was called", async () =>

--- a/test/mocks/lido/LidoMock.test.ts
+++ b/test/mocks/lido/LidoMock.test.ts
@@ -23,10 +23,10 @@ describeForEachPool.type("Lido Mock", [PoolType.Lido], (testPool:PoolTestFixture
   {
     it("Should have correct initial values", async () =>
     {
-      expect(await lido.totalSupply()).to.equal(0.0); // alias to getTotalPooledEther()
-      expect(await lido.getTotalShares()).to.equal(0.0);
-      expect(await lido.getPooledEthByShares(1.0)).to.equal(1.0);
-      expect(await lido.getSharesByPooledEth(1.0)).to.equal(1.0);
+      expect(+await lido.totalSupply()).to.equal(0.0); // alias to getTotalPooledEther()
+      expect(+await lido.getTotalShares()).to.equal(0.0);
+      expect(+await lido.getPooledEthByShares(1.0)).to.equal(1.0);
+      expect(+await lido.getSharesByPooledEth(1.0)).to.equal(1.0);
     });
   });
 
@@ -37,14 +37,14 @@ describeForEachPool.type("Lido Mock", [PoolType.Lido], (testPool:PoolTestFixture
       await lido.sendToContract(owner, 4.0); // join Lido
       await lido.submit(user, 2.0); // join Lido
 
-      expect(await lido.totalSupply()).to.equal(6.0); // alias to getTotalPooledEther()
-      expect(await lido.getTotalShares()).to.equal(6.0);
+      expect(+await lido.totalSupply()).to.equal(6.0); // alias to getTotalPooledEther()
+      expect(+await lido.getTotalShares()).to.equal(6.0);
 
-      expect(await lido.balanceOf(owner)).to.equal(4.0);
-      expect(await lido.balanceOf(user)).to.equal(2.0);
+      expect(+await lido.balanceOf(owner)).to.equal(4.0);
+      expect(+await lido.balanceOf(user)).to.equal(2.0);
 
-      expect(await lido.sharesOf(owner)).to.equal(4.0);
-      expect(await lido.sharesOf(user)).to.equal(2.0);
+      expect(+await lido.sharesOf(owner)).to.equal(4.0);
+      expect(+await lido.sharesOf(user)).to.equal(2.0);
     });
 
     it("Should reject ZERO deposit", async () =>
@@ -56,13 +56,13 @@ describeForEachPool.type("Lido Mock", [PoolType.Lido], (testPool:PoolTestFixture
     {
       await lido.submit(owner, 8.0);
       await lido.depositBufferedEther2(1);
-      expect(await lido.totalSupply()).to.equal(8.0);
-      expect(await lido.sharesOf(owner)).to.equal(8.0);
+      expect(+await lido.totalSupply()).to.equal(8.0);
+      expect(+await lido.sharesOf(owner)).to.equal(8.0);
       
       await lido.submit(owner, 32.0);
       await lido.depositBufferedEther();
-      expect(await lido.totalSupply()).to.equal(40.0);
-      expect(await lido.sharesOf(owner)).to.equal(40.0);
+      expect(+await lido.totalSupply()).to.equal(40.0);
+      expect(+await lido.sharesOf(owner)).to.equal(40.0);
     });
 
     it("Should increase account balances after rewards in fixed proportion", async () =>
@@ -77,13 +77,11 @@ describeForEachPool.type("Lido Mock", [PoolType.Lido], (testPool:PoolTestFixture
       await lido.pushBeaconRewards(owner, 1, rewards);
       //await lido.printState("after pushBeaconRewards (1 eth)");
 
-      expect(await lido.totalSupply()).to.equal(initial + rewards);
-      expect(await lido.getTotalShares()).to.equal('50.098231827111984282');
+      expect(+await lido.totalSupply()).to.equal(initial + rewards);
+      expect((await lido.getTotalShares()).toString()).to.equal('50.098231827111984282');
 
-      const ownerBalance = await lido.balanceOf(owner);
-      const userBalance  = await lido.balanceOf(user);
-      expect(ownerBalance).to.equal(10.18);
-      expect(userBalance).to.equal(40.72);
+      expect(+await lido.balanceOf(owner)).to.equal(10.18);
+      expect(+await lido.balanceOf(user)).to.equal(40.72);
     });
   });
 
@@ -98,13 +96,13 @@ describeForEachPool.type("Lido Mock", [PoolType.Lido], (testPool:PoolTestFixture
 
       // Three validators and total balance of 34, i.e accrued 2 eth of yield
       await lido.pushBeacon(owner, 1, 34.0);
-      expect(await lido.sharesOf(owner)).to.equal(32.0);
-      expect(await lido.sharesOf(user)).to.equal(66.0);
+      expect(+await lido.sharesOf(owner)).to.equal(32.0);
+      expect(+await lido.sharesOf(user)).to.equal(66.0);
 
       // Withdraw some ether
       await lido.withdraw(owner, 32.0);
-      expect(await lido.sharesOf(owner)).to.equal(0.0);
-      expect(await lido.sharesOf(user)).to.equal(66.0);
+      expect(+await lido.sharesOf(owner)).to.equal(0.0);
+      expect(+await lido.sharesOf(user)).to.equal(66.0);
 
       (await expectRevert(lido.withdraw(owner, 100.0)))
         .to.equal("Can only withdraw up to the buffered ether.");
@@ -116,13 +114,13 @@ describeForEachPool.type("Lido Mock", [PoolType.Lido], (testPool:PoolTestFixture
     it("Should have different redeemable ETH with exchangeRate 1.25", async () =>
     {
       await lido.submit(user, 32.0);
-      expect(await lido.sharesOf(user)).to.equal(32.0);
+      expect(+await lido.sharesOf(user)).to.equal(32.0);
       
       await lido.setInterestRate(1.25);
-      expect(await lido.interestRate()).to.equal(1.25);
+      expect(+await lido.interestRate()).to.equal(1.25);
 
       const redeemable = await lido.getPooledEthByShares(10);
-      expect(redeemable).to.equal(12.5, "redeemable ETH should increase by 1.25x with interestRate 1.25x");
+      expect(+redeemable).to.equal(12.5, "redeemable ETH should increase by 1.25x with interestRate 1.25x");
     });
 
     it("Should revert if underlying pool has a random error", async () =>

--- a/test/otc/TempusOTC.test.ts
+++ b/test/otc/TempusOTC.test.ts
@@ -51,20 +51,20 @@ describeNonPool("TempusOTC", async() =>
 
   it("check create offer (contract deploy) works good", async () =>
   {
-    expect(await tempusOTC.tokenToBuy.balanceOf(tempusOTC.address)).to.equal(buyAmount);
+    expect(+await tempusOTC.tokenToBuy.balanceOf(tempusOTC.address)).to.equal(buyAmount);
   });
 
   it("check if [buy] works good", async () =>
   {
     await tempusOTC.buy(taker);
 
-    expect(await tempusOTC.tokenToBuy.balanceOf(tempusOTC.address)).to.equal(0);
-    expect(await tempusOTC.tokenToBuy.balanceOf(maker)).to.equal(tokenToBuyMakerAmount);
-    expect(await tempusOTC.tokenToBuy.balanceOf(taker)).to.equal(tokenToBuyTakerAmount + buyAmount);
+    expect(+await tempusOTC.tokenToBuy.balanceOf(tempusOTC.address)).to.equal(0);
+    expect(+await tempusOTC.tokenToBuy.balanceOf(maker)).to.equal(tokenToBuyMakerAmount);
+    expect(+await tempusOTC.tokenToBuy.balanceOf(taker)).to.equal(tokenToBuyTakerAmount + buyAmount);
 
-    expect(await tempusOTC.tokenToSell.balanceOf(tempusOTC.address)).to.equal(0);
-    expect(await tempusOTC.tokenToSell.balanceOf(maker)).to.equal(tokenToSellMakerAmount + sellAmount);
-    expect(await tempusOTC.tokenToSell.balanceOf(taker)).to.equal(tokenToSellTakerAmount - sellAmount);
+    expect(+await tempusOTC.tokenToSell.balanceOf(tempusOTC.address)).to.equal(0);
+    expect(+await tempusOTC.tokenToSell.balanceOf(maker)).to.equal(tokenToSellMakerAmount + sellAmount);
+    expect(+await tempusOTC.tokenToSell.balanceOf(taker)).to.equal(tokenToSellTakerAmount - sellAmount);
   });
 
   it("check if [buy] reverts", async () => 
@@ -85,13 +85,13 @@ describeNonPool("TempusOTC", async() =>
   {
     await tempusOTC.cancel(maker);
 
-    expect(await tempusOTC.tokenToBuy.balanceOf(tempusOTC.address)).to.equal(0);
-    expect(await tempusOTC.tokenToBuy.balanceOf(maker)).to.equal(tokenToBuyMakerAmount + buyAmount);
-    expect(await tempusOTC.tokenToBuy.balanceOf(taker)).to.equal(tokenToBuyTakerAmount);
+    expect(+await tempusOTC.tokenToBuy.balanceOf(tempusOTC.address)).to.equal(0);
+    expect(+await tempusOTC.tokenToBuy.balanceOf(maker)).to.equal(tokenToBuyMakerAmount + buyAmount);
+    expect(+await tempusOTC.tokenToBuy.balanceOf(taker)).to.equal(tokenToBuyTakerAmount);
 
-    expect(await tempusOTC.tokenToSell.balanceOf(tempusOTC.address)).to.equal(0);
-    expect(await tempusOTC.tokenToSell.balanceOf(maker)).to.equal(tokenToSellMakerAmount);
-    expect(await tempusOTC.tokenToSell.balanceOf(taker)).to.equal(tokenToSellTakerAmount);
+    expect(+await tempusOTC.tokenToSell.balanceOf(tempusOTC.address)).to.equal(0);
+    expect(+await tempusOTC.tokenToSell.balanceOf(maker)).to.equal(tokenToSellMakerAmount);
+    expect(+await tempusOTC.tokenToSell.balanceOf(taker)).to.equal(tokenToSellTakerAmount);
   });
 
   it("check if [cancel] reverts", async () => 

--- a/test/pool-utils/PoolTestFixture.ts
+++ b/test/pool-utils/PoolTestFixture.ts
@@ -367,9 +367,9 @@ export abstract class PoolTestFixture {
    */
   async userState(user:Signer): Promise<UserState> {
     let state = new UserState();
-    state.principalShares = Number(await this.principals.balanceOf(user));
-    state.yieldShares = Number(await this.yields.balanceOf(user));
-    state.yieldBearing = Number(await this.ybt.balanceOf(user));
+    state.principalShares = (await this.principals.balanceOf(user)).toNumber();
+    state.yieldShares = (await this.yields.balanceOf(user)).toNumber();
+    state.yieldBearing = (await this.ybt.balanceOf(user)).toNumber();
     state.yieldPeggedToAsset = this.yieldPeggedToAsset;
     return state;
   }

--- a/test/token/ERC20OwnerMintableToken.test.ts
+++ b/test/token/ERC20OwnerMintableToken.test.ts
@@ -19,8 +19,8 @@ describeNonPool("Owner Mintable Token", async () => {
     it("Should set the right owner and initial supply", async () =>
     {
       expect(await token.manager()).to.equal(owner.address);
-      expect(await token.balanceOf(owner)).to.equal(0);
-      expect(await token.totalSupply()).to.equal(0);
+      expect(+await token.balanceOf(owner)).to.equal(0);
+      expect(+await token.totalSupply()).to.equal(0);
     });
 
     it("Should set name and symbol", async () =>
@@ -36,15 +36,15 @@ describeNonPool("Owner Mintable Token", async () => {
     {
       // owner mints to himself
       await token.mint(owner, owner, 10);
-      expect(await token.balanceOf(owner)).to.equal(10);
-      expect(await token.totalSupply()).to.equal(10);
+      expect(+await token.balanceOf(owner)).to.equal(10);
+      expect(+await token.totalSupply()).to.equal(10);
     });
 
     it("Should allow Owner to mint to User", async () =>
     {
       await token.mint(owner, user, 10); // Owner mints to User
-      expect(await token.balanceOf(user)).to.equal(10);
-      expect(await token.totalSupply()).to.equal(10);
+      expect(+await token.balanceOf(user)).to.equal(10);
+      expect(+await token.totalSupply()).to.equal(10);
     });
 
     it("Should not allow Users to mint to User", async () =>
@@ -63,34 +63,34 @@ describeNonPool("Owner Mintable Token", async () => {
     it("Should allow Owner to burn his own tokens", async () =>
     {
       await token.mint(owner, owner, 10); // Owner mints to Owner
-      expect(await token.balanceOf(owner)).to.equal(10);
-      expect(await token.totalSupply()).to.equal(10);
+      expect(+await token.balanceOf(owner)).to.equal(10);
+      expect(+await token.totalSupply()).to.equal(10);
 
       await token.burn(owner, 5); // Owner burns Owner
-      expect(await token.balanceOf(owner)).to.equal(5);
-      expect(await token.totalSupply()).to.equal(5);
+      expect(+await token.balanceOf(owner)).to.equal(5);
+      expect(+await token.totalSupply()).to.equal(5);
 
       await token.burnFrom(owner, owner, 5);
-      expect(await token.balanceOf(owner)).to.equal(0);
-      expect(await token.totalSupply()).to.equal(0);
+      expect(+await token.balanceOf(owner)).to.equal(0);
+      expect(+await token.totalSupply()).to.equal(0);
     });
 
     it("Should allow Owner to burn User tokens", async () =>
     {
       await token.mint(owner, user, 8); // Owner mints to User
-      expect(await token.balanceOf(user)).to.equal(8);
-      expect(await token.totalSupply()).to.equal(8);
+      expect(+await token.balanceOf(user)).to.equal(8);
+      expect(+await token.totalSupply()).to.equal(8);
 
       await token.burnFrom(owner, user, 8); // Owner burns User
-      expect(await token.balanceOf(user)).to.equal(0);
-      expect(await token.totalSupply()).to.equal(0);
+      expect(+await token.balanceOf(user)).to.equal(0);
+      expect(+await token.totalSupply()).to.equal(0);
     });
 
     it("Should not allow Users to burn their own tokens", async () =>
     {
       await token.mint(owner, user, 10); // Owner mints to User
-      expect(await token.balanceOf(user)).to.equal(10);
-      expect(await token.totalSupply()).to.equal(10);
+      expect(+await token.balanceOf(user)).to.equal(10);
+      expect(+await token.totalSupply()).to.equal(10);
 
       // User tries to burn User tokens
       (await expectRevert(token.burn(user, 5))).to.equal("burn: only manager can burn");
@@ -102,8 +102,8 @@ describeNonPool("Owner Mintable Token", async () => {
     it("Should not allow Users to burn Owners tokens", async () =>
     {
       await token.mint(owner, owner, 10); // Owner mints to Owner
-      expect(await token.balanceOf(owner)).to.equal(10);
-      expect(await token.totalSupply()).to.equal(10);
+      expect(+await token.balanceOf(owner)).to.equal(10);
+      expect(+await token.totalSupply()).to.equal(10);
 
       // User tries to burn Owner tokens
       (await expectRevert(token.burnFrom(user, owner, 5))).to.equal("burn: only manager can burn");
@@ -113,8 +113,8 @@ describeNonPool("Owner Mintable Token", async () => {
     it("Should not allow Owner to burn more User tokens than available", async () =>
     {
       await token.mint(owner, user, 5); // Owner mints to User
-      expect(await token.balanceOf(user)).to.equal(5);
-      expect(await token.totalSupply()).to.equal(5);
+      expect(+await token.balanceOf(user)).to.equal(5);
+      expect(+await token.totalSupply()).to.equal(5);
 
       // Owner burns User, but more than exists
       (await expectRevert(token.burnFrom(owner, user, 10))).to.equal("ERC20: burn amount exceeds balance");

--- a/test/token/TempusToken.test.ts
+++ b/test/token/TempusToken.test.ts
@@ -30,8 +30,8 @@ describeNonPool("Tempus Token", async () => {
     });
     it("Should mint initial supply to owner", async () =>
     {
-      expect(await token.balanceOf(owner)).to.equal(1e9);
-      expect(await token.totalSupply()).to.equal(1e9);
+      expect(+await token.balanceOf(owner)).to.equal(1e9);
+      expect(+await token.totalSupply()).to.equal(1e9);
     });
 
     it("Should set name and symbol", async () =>
@@ -49,12 +49,12 @@ describeNonPool("Tempus Token", async () => {
       const initialTotalSupply = await token.totalSupply();
 
       await token.transfer(owner, user1, amount); // Owner transfers to User
-      expect(await token.balanceOf(user1)).to.equal(amount);
+      expect(+await token.balanceOf(user1)).to.equal(amount);
 
       // User tries to burn its own tokens
       await token.burn(user1, amount);
-      expect(await token.balanceOf(user1)).to.equal(0);
-      expect(await token.totalSupply()).to.equal(Number(initialTotalSupply) - amount);
+      expect(+await token.balanceOf(user1)).to.equal(0);
+      expect(+await token.totalSupply()).to.equal(+initialTotalSupply - amount);
     });
   });
 
@@ -81,14 +81,14 @@ describeNonPool("Tempus Token", async () => {
       const firstMintAmount = 2e7;
       await token.mint(owner, user1, firstMintAmount.toString());
       expect(await token.lastMintingTime()).gte(lastMintTime);
-      expect(await token.balanceOf(user1)).to.equal(firstMintAmount);
-      expect(await token.totalSupply()).to.equal(initialSupply + firstMintAmount);
+      expect(+await token.balanceOf(user1)).to.equal(firstMintAmount);
+      expect(+await token.totalSupply()).to.equal(initialSupply + firstMintAmount);
       
       await increaseTime(DAY * 365);
       const secontMintAmount = (initialSupply + firstMintAmount) / 50;
       await token.mint(owner, user1, secontMintAmount);
-      expect(await token.balanceOf(user1)).to.equal(firstMintAmount + secontMintAmount);
-      expect(await token.totalSupply()).to.equal(initialSupply + firstMintAmount + secontMintAmount);
+      expect(+await token.balanceOf(user1)).to.equal(firstMintAmount + secontMintAmount);
+      expect(+await token.totalSupply()).to.equal(initialSupply + firstMintAmount + secontMintAmount);
     });
   });
 });

--- a/test/token/vesting/ERC20TokenVesting.test.ts
+++ b/test/token/vesting/ERC20TokenVesting.test.ts
@@ -159,7 +159,7 @@ describeNonPool("ERC20 Vesting", async () => {
       expect(terms.period).to.equal(period);
       expect(terms.claimed).to.equal(0);
 
-      expect(await token.balanceOf(owner)).to.equal(270);
+      expect(+await token.balanceOf(owner)).to.equal(270);
     });
 
     it("Expected claimable tokens is 0 after startVesting with startTime in future", async () => {
@@ -196,7 +196,7 @@ describeNonPool("ERC20 Vesting", async () => {
       expect(terms2.period).to.equal(period);
       expect(terms2.claimed).to.equal(0);
 
-      expect(await token.balanceOf(owner)).to.equal(210);
+      expect(+await token.balanceOf(owner)).to.equal(210);
     });
 
     it("Expected state after stopVesting (after period)", async () => {
@@ -221,8 +221,8 @@ describeNonPool("ERC20 Vesting", async () => {
 
       expect(await vesting.claimable(user)).to.equal(30);
 
-      expect(await token.balanceOf(user)).to.equal(0);
-      expect(await token.balanceOf(owner)).to.equal(270);
+      expect(+await token.balanceOf(user)).to.equal(0);
+      expect(+await token.balanceOf(owner)).to.equal(270);
     });
 
     it("Expected state after stopVesting called after vesting period expires and all tokens claimed", async () => {
@@ -235,7 +235,7 @@ describeNonPool("ERC20 Vesting", async () => {
       );
       await increaseTime(DAY);
       await vesting.claim(user);
-      expect(await token.balanceOf(user)).to.equal(30);
+      expect(+await token.balanceOf(user)).to.equal(30);
       
       await vesting.stopVesting(owner, user);
   
@@ -247,8 +247,8 @@ describeNonPool("ERC20 Vesting", async () => {
 
       expect(await vesting.claimable(user)).to.equal(0);
 
-      expect(await token.balanceOf(user)).to.equal(30);
-      expect(await token.balanceOf(owner)).to.equal(270);
+      expect(+await token.balanceOf(user)).to.equal(30);
+      expect(+await token.balanceOf(owner)).to.equal(270);
     });
 
     it("Claiming after period finished", async () => {
@@ -266,7 +266,7 @@ describeNonPool("ERC20 Vesting", async () => {
         vesting.contract,
         "VestingClaimed"
       ).withArgs(addressOf(user), vesting.toBigNum(amountToClaim));
-      expect(await token.balanceOf(user)).to.equal(30);
+      expect(+await token.balanceOf(user)).to.equal(30);
     });
 
     it("Claiming specific amount after half period", async () => {
@@ -342,7 +342,7 @@ describeNonPool("ERC20 Vesting", async () => {
         user,
         {startTime: startTime, period: period, amount: 30, claimed: 0}
       );
-      expect(await token.balanceOf(owner)).to.equal(270);
+      expect(+await token.balanceOf(owner)).to.equal(270);
 
       expect(await vesting.transferVesting(owner, user, user2)).to.emit(
         vesting.contract, 
@@ -370,7 +370,7 @@ describeNonPool("ERC20 Vesting", async () => {
         user,
         {startTime: startTime, period: period, amount: 30, claimed: 0}
       );
-      expect(await token.balanceOf(owner)).to.equal(270);
+      expect(+await token.balanceOf(owner)).to.equal(270);
 
       await increaseTime(period / 2);
       await vesting.claim(user, await vesting.claimable(user));
@@ -408,7 +408,7 @@ describeNonPool("ERC20 Vesting", async () => {
         user2,
         {startTime: startTime + 10, period: period + 10, amount: 10, claimed: 0}
       );
-      expect(await token.balanceOf(owner)).to.equal(260);
+      expect(+await token.balanceOf(owner)).to.equal(260);
 
       (await expectRevert(vesting.transferVesting(owner, user, user2))).to.equal("Vesting already started for receiver.");
 

--- a/test/utils/Aave.ts
+++ b/test/utils/Aave.ts
@@ -1,5 +1,5 @@
 import { Contract } from "ethers";
-import { Numberish, toRay, fromRay, parseDecimal } from "./Decimal";
+import { Decimal, Numberish, toRay, fromRay, parseDecimal } from "./Decimal";
 import { ContractBase, SignerOrAddress, addressOf } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 import { TokenInfo } from "../pool-utils/TokenInfo";
@@ -33,16 +33,15 @@ export class Aave extends ContractBase {
   /**
    * @return Current Asset balance of the user as a decimal, eg. 1.0
    */
-  async assetBalance(user:SignerOrAddress): Promise<Numberish> {
+  async assetBalance(user:SignerOrAddress): Promise<Decimal> {
     return await this.asset.balanceOf(user);
   }
 
   /**
    * @return Yield Token balance of the user as a decimal, eg. 2.0
    */
-  async yieldBalance(user:SignerOrAddress): Promise<Numberish> {
-    let wei = await this.contract.getDeposit(addressOf(user));
-    return this.fromBigNum(wei);
+  async yieldBalance(user:SignerOrAddress): Promise<Decimal> {
+    return this.toDecimal(await this.contract.getDeposit(addressOf(user)));
   }
 
   /**
@@ -62,7 +61,7 @@ export class Aave extends ContractBase {
       const difference = (Number(liquidityIndex) / Number(prevLiquidityIndex)) - 1;
       if (difference > 0) {
         const totalSupply = await this.asset.balanceOf(this.yieldToken.address);
-        const increaseBy = Number(totalSupply) * difference;
+        const increaseBy = totalSupply.mul(difference);
         await this.asset.transfer(owner, this.yieldToken.address, increaseBy);
       }
     }

--- a/test/utils/Comptroller.ts
+++ b/test/utils/Comptroller.ts
@@ -1,5 +1,5 @@
 import { Contract, BigNumber } from "ethers";
-import { formatDecimal, Numberish, parseDecimal } from "./Decimal";
+import { Decimal, formatDecimal, Numberish, parseDecimal } from "./Decimal";
 import { addressOf, ContractBase, SignerOrAddress } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 import { TokenInfo } from "../pool-utils/TokenInfo";
@@ -39,14 +39,14 @@ export class Comptroller extends ContractBase {
   /**
    * @return Current Asset balance of the user as a decimal, eg. 1.0
    */
-  async assetBalance(user:SignerOrAddress): Promise<Numberish> {
+  async assetBalance(user:SignerOrAddress): Promise<Decimal> {
     return await this.asset.balanceOf(user);
   }
 
   /**
    * @return Yield Token balance of the user as a decimal, eg. 2.0
    */
-  async yieldBalance(user:SignerOrAddress): Promise<Numberish> {
+  async yieldBalance(user:SignerOrAddress): Promise<Decimal> {
     return await this.yieldToken.balanceOf(user);
   }
 
@@ -67,7 +67,7 @@ export class Comptroller extends ContractBase {
       const difference = (Number(exchangeRate) / Number(prevExchangeRate)) - 1;
       if (difference > 0) {
         const totalSupply = await this.asset.balanceOf(this.yieldToken.address);
-        const increaseBy = Number(totalSupply) * difference;
+        const increaseBy = totalSupply.mul(difference);
         await this.asset.transfer(owner, this.yieldToken.address, increaseBy);
       }
     }

--- a/test/utils/Decimal.ts
+++ b/test/utils/Decimal.ts
@@ -151,6 +151,11 @@ export class Decimal {
     return this.toDecimal( (this.int * this.one()) / this.toScaledBigInt(x) );
   }
 
+  /** @return Absolute value of this decimal */
+  public abs(): Decimal {
+    return new Decimal(this.int >= 0 ? this.int : -this.int, this.decimals);
+  }
+
   /**
    * Main utility for converting numeric values into the internal
    * scaled fixed point integer representation.

--- a/test/utils/ERC20.ts
+++ b/test/utils/ERC20.ts
@@ -83,17 +83,17 @@ export class ERC20 extends ContractBase implements IERC20 {
   /**
    * @returns Total supply of this ERC20 token as a decimal, such as 10.0
    */
-  async totalSupply(): Promise<Numberish> {
-    return this.fromBigNum(await this.contract.totalSupply());
+  async totalSupply(): Promise<Decimal> {
+    return this.toDecimal(await this.contract.totalSupply());
   }
 
   /**
    * @param account ERC20 account's address
    * @returns Balance of ERC20 address in decimals, eg 2.0
    */
-  async balanceOf(account:Addressable): Promise<Numberish> {
+  async balanceOf(account:Addressable): Promise<Decimal> {
     const amount = await this.contract.balanceOf(addressOf(account));
-    return this.fromBigNum(amount);
+    return this.toDecimal(amount);
   }
 
   /**

--- a/test/utils/ERC20Ether.ts
+++ b/test/utils/ERC20Ether.ts
@@ -1,5 +1,5 @@
 import { ethers } from "hardhat";
-import { Numberish, DecimalConvertible } from "./Decimal";
+import { Decimal, Numberish, DecimalConvertible } from "./Decimal";
 import { Signer, Addressable, addressOf } from "./ContractBase";
 import { IERC20 } from "./IERC20";
 
@@ -30,9 +30,9 @@ export class ERC20Ether extends DecimalConvertible implements IERC20 {
    * @param account ERC20 account's address
    * @returns Balance of ERC20 address in decimals, eg 2.0
    */
-  async balanceOf(account:Addressable): Promise<Numberish> {
+  async balanceOf(account:Addressable): Promise<Decimal> {
     const balance = await ethers.provider.getBalance(addressOf(account));
-    return this.fromBigNum(balance);
+    return this.toDecimal(balance);
   }
 
   /**

--- a/test/utils/IERC20.ts
+++ b/test/utils/IERC20.ts
@@ -1,4 +1,4 @@
-import { Numberish } from "./Decimal";
+import { Decimal, Numberish } from "./Decimal";
 import { Addressable } from "./ContractBase";
 import { BigNumber } from "@ethersproject/bignumber";
 
@@ -22,7 +22,7 @@ export interface IERC20 {
    * @param account ERC20 account's address
    * @returns Balance of ERC20 address in decimals, eg 2.0
    */
-  balanceOf(account:Addressable): Promise<Numberish>;
+  balanceOf(account:Addressable): Promise<Decimal>;
 
   /**
    * @dev Moves `amount` tokens from the sender's account to `recipient`.

--- a/test/utils/LidoContract.ts
+++ b/test/utils/LidoContract.ts
@@ -1,6 +1,6 @@
 import { ethers } from "hardhat";
 import { BigNumber, Contract } from "ethers";
-import { formatDecimal, Numberish, parseDecimal } from "./Decimal";
+import { Decimal, Numberish, parseDecimal } from "./Decimal";
 import { SignerOrAddress, Signer, addressOf } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 import { ERC20Ether } from "./ERC20Ether";
@@ -16,28 +16,28 @@ export abstract class LidoContract extends ERC20 {
   }
 
   /** @return stETH balance of an user */
-  async sharesOf(user:SignerOrAddress): Promise<Numberish> {
-    return this.fromBigNum(await this.contract.sharesOf(addressOf(user)));
+  async sharesOf(user:SignerOrAddress): Promise<Decimal> {
+    return this.toDecimal(await this.contract.sharesOf(addressOf(user)));
   }
 
   /** @return total stETH shares minted */
-  async getTotalShares(): Promise<Numberish> {
-    return this.fromBigNum(await this.contract.getTotalShares());
+  async getTotalShares(): Promise<Decimal> {
+    return this.toDecimal(await this.contract.getTotalShares());
   }
 
   /** @return the amount of Ether that corresponds to `_sharesAmount` token shares. */
-  async getPooledEthByShares(sharesAmount:Numberish): Promise<Numberish> {
-    return this.fromBigNum(await this.contract.getPooledEthByShares(this.toBigNum(sharesAmount)));
+  async getPooledEthByShares(sharesAmount:Numberish): Promise<Decimal> {
+    return this.toDecimal(await this.contract.getPooledEthByShares(this.toBigNum(sharesAmount)));
   }
 
   /** @return the amount of shares that corresponds to `_ethAmount` protocol-controlled Ether. */
-  async getSharesByPooledEth(_ethAmount:Numberish): Promise<Numberish> {
-    return this.fromBigNum(await this.contract.getSharesByPooledEth(this.toBigNum(_ethAmount)));
+  async getSharesByPooledEth(_ethAmount:Numberish): Promise<Decimal> {
+    return this.toDecimal(await this.contract.getSharesByPooledEth(this.toBigNum(_ethAmount)));
   }
 
   /** @return total pooled ETH: beaconBalance + bufferedEther */
-  async totalSupply(): Promise<Numberish> {
-    return this.fromBigNum(await this.contract.totalSupply());
+  async totalSupply(): Promise<Decimal> {
+    return this.toDecimal(await this.contract.totalSupply());
   }
 
   // Interest rate as 1e18 BigNumber
@@ -49,8 +49,8 @@ export abstract class LidoContract extends ERC20 {
   }
 
   /** @return Stored Interest Rate */
-  async interestRate(): Promise<Numberish> {
-    return this.fromBigNum(await this.interestRateBigNum());
+  async interestRate(): Promise<Decimal> {
+    return this.toDecimal(await this.interestRateBigNum());
   }
 
   /**

--- a/test/utils/TempusPool.ts
+++ b/test/utils/TempusPool.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BytesLike, Contract, Transaction } from "ethers";
-import { Numberish, toWei, parseDecimal, formatDecimal, MAX_UINT256 } from "./Decimal";
+import { Decimal, Numberish, toWei, parseDecimal, formatDecimal, MAX_UINT256 } from "./Decimal";
 import { ContractBase, Signer, SignerOrAddress, addressOf } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 import { IERC20 } from "./IERC20";
@@ -364,7 +364,7 @@ export class TempusPool extends ContractBase {
   /**
    * @returns Number of YBT deposited into this TempusPool contract
    */
-  async contractBalance(): Promise<Numberish> {
+  async contractBalance(): Promise<Decimal> {
     return this.yieldBearing.balanceOf(this.contract.address);
   }
 
@@ -556,8 +556,8 @@ export class TempusPool extends ContractBase {
   /**
    * @returns Total accumulated fees
    */
-  async totalFees(): Promise<Numberish> {
-    return this.yieldBearing.fromBigNum(await this.contract.totalFees());
+  async totalFees(): Promise<Decimal> {
+    return this.yieldBearing.toDecimal(await this.contract.totalFees());
   }
 
   async getFeesConfig(): Promise<TempusFeesConfig> {

--- a/test/utils/YearnVault.ts
+++ b/test/utils/YearnVault.ts
@@ -42,7 +42,7 @@ export class YearnVault extends ContractBase {
       const difference = (Number(pricePerShare) / Number(prevExchangeRate)) - 1;
       if (difference > 0) {
         const totalSupply = await this.asset.balanceOf(this.yieldToken.address);
-        const increaseBy = Number(totalSupply) * difference;
+        const increaseBy = totalSupply.mul(difference);
         await this.asset.transfer(owner, this.yieldToken.address, increaseBy);
       }
     }


### PR DESCRIPTION
Changes several `balanceOf()` related interfaces to use `Decimal` as the return type.

To make existing tests work, a lot of `+` conversions were added.