### PR TITLE
refactor: replace most usages with the new `Addressable` alias

### DIFF
--- a/integration-tests/IntegrationUtils.ts
+++ b/integration-tests/IntegrationUtils.ts
@@ -2,7 +2,6 @@ import { ethers, getNamedAccounts, getUnnamedAccounts } from 'hardhat';
 import { ERC20 } from "@tempus-sdk/utils/ERC20";
 import { Decimal, decimal } from "@tempus-sdk/utils/Decimal";
 import { Signer } from '@tempus-sdk/utils/ContractBase';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signers';
 
 export class Balances
 {
@@ -58,9 +57,9 @@ export async function getAccounts(holderName?:string) {
 /**
  * Maps account names into Signers
  */
-export async function getNamedSigners(accounts:string[]): Promise<SignerWithAddress[]> {
+export async function getNamedSigners(accounts:string[]): Promise<Signer[]> {
   const namedAccounts = await getNamedAccounts();
-  const signers:SignerWithAddress[] = [];
+  const signers:Signer[] = [];
   for (const account of accounts) {
     const signer = await ethers.getSigner(namedAccounts[account]);
     signers.push(signer);

--- a/integration-tests/TempusPool.compound.test.ts
+++ b/integration-tests/TempusPool.compound.test.ts
@@ -7,7 +7,7 @@ import { TempusController } from "@tempus-sdk/tempus/TempusController";
 import { ERC20 } from "@tempus-sdk/utils/ERC20";
 import { bn, Numberish, toWei } from "@tempus-sdk/utils/DecimalUtils";
 import { Balances, getAccounts } from "./IntegrationUtils";
-import { SignerOrAddress } from "@tempus-sdk/utils/ContractBase";
+import { Addressable } from "@tempus-sdk/utils/ContractBase";
 
 const setupDai = deployments.createFixture(async () => {
   await deployments.fixture(undefined, { keepExistingDeployments: true, });
@@ -51,7 +51,7 @@ const setupUsdc = deployments.createFixture(async () => {
   return { contracts: { tempusPool, usdc, cUsdc }, signers: { signer1, signer2 } };
 });
 
-async function depositBacking(user:SignerOrAddress, pool:TempusPool, amount:Numberish) {
+async function depositBacking(user:Addressable, pool:TempusPool, amount:Numberish) {
   await pool.asset.approve(user, pool.controller, amount);
   await pool.controller.depositBacking(user, pool, amount, user);
 }

--- a/scripts/deposit.local.fork.ts
+++ b/scripts/deposit.local.fork.ts
@@ -1,10 +1,10 @@
 import { ethers, network } from 'hardhat';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signers';
 import { ERC20 } from '@tempus-sdk/utils/ERC20';
+import { Signer } from '@tempus-sdk/utils/ContractBase';
 import depositConfig from '../deposit.local.config';
 
 class DepositLocalForked {
-  private owner: SignerWithAddress;
+  private owner: Signer;
 
   public async deploy() {
     this.owner = (await ethers.getSigners())[0];

--- a/tempus-sdk/tempus/ERC20OwnerMintable.ts
+++ b/tempus-sdk/tempus/ERC20OwnerMintable.ts
@@ -1,6 +1,6 @@
 import { Contract } from "ethers";
 import { Numberish } from "../utils/DecimalUtils";
-import { SignerOrAddress, addressOf } from "../utils/ContractBase";
+import { Addressable, addressOf } from "../utils/ContractBase";
 import { ERC20 } from "../utils/ERC20";
 
 /**
@@ -26,7 +26,7 @@ export class ERC20OwnerMintable extends ERC20 {
    * @param receiver Recipient address to mint tokens to
    * @param amount Number of tokens to mint
    */
-  async mint(sender:SignerOrAddress, receiver:SignerOrAddress, amount:Numberish): Promise<void> {
+  async mint(sender:Addressable, receiver:Addressable, amount:Numberish): Promise<void> {
     await this.connect(sender).mint(addressOf(receiver), this.toBigNum(amount));
   }
 
@@ -34,7 +34,7 @@ export class ERC20OwnerMintable extends ERC20 {
    * @param sender Account that is issuing the burn. Must be manager().
    * @param amount Number of tokens to burn
    */
-  async burn(sender:SignerOrAddress, amount:Numberish): Promise<void> {
+  async burn(sender:Addressable, amount:Numberish): Promise<void> {
     await this.connect(sender).burn(this.toBigNum(amount));
   }
 
@@ -43,7 +43,7 @@ export class ERC20OwnerMintable extends ERC20 {
    * @param account Source address to burn tokens from
    * @param amount Number of tokens to burn
    */
-  async burnFrom(sender:SignerOrAddress, account:SignerOrAddress, amount:Numberish): Promise<void> {
+  async burnFrom(sender:Addressable, account:Addressable, amount:Numberish): Promise<void> {
     await this.connect(sender).burnFrom(addressOf(account), this.toBigNum(amount));
   }
 }

--- a/tempus-sdk/tempus/TempusController.ts
+++ b/tempus-sdk/tempus/TempusController.ts
@@ -1,6 +1,6 @@
 import { Contract, Transaction } from "ethers";
 import { Numberish, toWei } from "../utils/DecimalUtils";
-import { ContractBase, Signer, SignerOrAddress, addressOf } from "../utils/ContractBase";
+import { ContractBase, Signer, Addressable, addressOf } from "../utils/ContractBase";
 import { TempusPool } from "./TempusPool";
 import { PoolTestFixture } from "../../test/pool-utils/PoolTestFixture";
 
@@ -47,7 +47,7 @@ export class TempusController extends ContractBase {
    * @param authorizedContract Address of the contract to authorize
    * @param isValid Is the contract authorized or not?
    */
-  async register(user:SignerOrAddress, authorizedContract:string, isValid:boolean = true): Promise<void> {
+  async register(user:Addressable, authorizedContract:string, isValid:boolean = true): Promise<void> {
     await this.connect(user).register(authorizedContract, isValid);
   }
 
@@ -59,7 +59,7 @@ export class TempusController extends ContractBase {
    * @param recipient Address or User who will receive the minted shares
    * @param ethValue value of ETH to send with the tx
    */
-  async depositYieldBearing(user:SignerOrAddress, pool: TempusPool, yieldBearingAmount:Numberish, recipient:SignerOrAddress = user, ethValue: Numberish = 0): Promise<Transaction> {
+  async depositYieldBearing(user:Addressable, pool: TempusPool, yieldBearingAmount:Numberish, recipient:Addressable = user, ethValue: Numberish = 0): Promise<Transaction> {
     await pool.yieldBearing.approve(user, this.contract.address, yieldBearingAmount);
     return this.connect(user).depositYieldBearing(
       pool.address, pool.yieldBearing.toBigNum(yieldBearingAmount),
@@ -75,7 +75,7 @@ export class TempusController extends ContractBase {
   * @param recipient Address or User who will receive the minted shares
   * @param ethValue value of ETH to send with the tx
   */
-  async depositBacking(user:SignerOrAddress, pool: TempusPool, backingAmount:Numberish, recipient:SignerOrAddress = user, ethValue: Numberish = 0): Promise<Transaction> {
+  async depositBacking(user:Addressable, pool: TempusPool, backingAmount:Numberish, recipient:Addressable = user, ethValue: Numberish = 0): Promise<Transaction> {
     return this.connect(user).depositBacking(
       pool.address, pool.asset.toBigNum(backingAmount),
       addressOf(recipient), { value: toWei(ethValue) }
@@ -90,7 +90,7 @@ export class TempusController extends ContractBase {
    * @param yieldAmount How many yield shares to redeem
    * @param recipient The recipient address (can be user)
    */
-  async redeemToBacking(user:SignerOrAddress, pool: TempusPool, principalAmount:Numberish, yieldAmount:Numberish, recipient:SignerOrAddress): Promise<Transaction> {
+  async redeemToBacking(user:Addressable, pool: TempusPool, principalAmount:Numberish, yieldAmount:Numberish, recipient:Addressable): Promise<Transaction> {
     return this.connect(user).redeemToBacking(
       pool.address, pool.principalShare.toBigNum(principalAmount), pool.yieldShare.toBigNum(yieldAmount), addressOf(recipient)
     );
@@ -104,7 +104,7 @@ export class TempusController extends ContractBase {
    * @param yieldAmount How many yield shares to redeem
    * @param recipient The recipient address (can be user)
    */
-  async redeemToYieldBearing(user:SignerOrAddress, pool: TempusPool, principalAmount:Numberish, yieldAmount:Numberish, recipient:SignerOrAddress): Promise<Transaction> {
+  async redeemToYieldBearing(user:Addressable, pool: TempusPool, principalAmount:Numberish, yieldAmount:Numberish, recipient:Addressable): Promise<Transaction> {
     return this.connect(user).redeemToYieldBearing(
       pool.address, pool.principalShare.toBigNum(principalAmount), pool.yieldShare.toBigNum(yieldAmount), addressOf(recipient)
     );
@@ -113,7 +113,7 @@ export class TempusController extends ContractBase {
   /**
    * Approves either BT or YBT transfer
    */
-  async approve(pool:PoolTestFixture, user:SignerOrAddress, amount:Numberish, isBackingToken:boolean) {
+  async approve(pool:PoolTestFixture, user:Addressable, amount:Numberish, isBackingToken:boolean) {
     const token = isBackingToken ? pool.asset : pool.ybt;
     await token.approve(user, this.address, amount);
   }
@@ -129,7 +129,7 @@ export class TempusController extends ContractBase {
    */
   async depositAndProvideLiquidity(
     pool: PoolTestFixture,
-    user: SignerOrAddress,
+    user: Addressable,
     tokenAmount: Numberish,
     isBackingToken: boolean,
     ethValue: Numberish = 0
@@ -153,7 +153,7 @@ export class TempusController extends ContractBase {
    */
   async depositAndFix(
     pool: PoolTestFixture,
-    user: SignerOrAddress,
+    user: Addressable,
     tokenAmount: Numberish,
     isBackingToken: boolean,
     minTYSRate: Numberish,
@@ -185,7 +185,7 @@ export class TempusController extends ContractBase {
    */
    async depositAndLeverage(
     pool: PoolTestFixture,
-    user: SignerOrAddress,
+    user: Addressable,
     tokenAmount: Numberish,
     isBackingToken: boolean,
     leverageMultiplier: Numberish,
@@ -209,7 +209,7 @@ export class TempusController extends ContractBase {
 
   async exitAmmGivenAmountsOutAndEarlyRedeem(
     pool: PoolTestFixture,
-    user: SignerOrAddress,
+    user: Addressable,
     principals: Numberish,
     yields: Numberish,
     principalsLp: Numberish,
@@ -217,7 +217,7 @@ export class TempusController extends ContractBase {
     toBackingToken: boolean
   ): Promise<Transaction> {
     const amm = pool.amm, t = pool.tempus;
-    await amm.contract.connect(user).approve(this.address, amm.contract.balanceOf(addressOf(user)));
+    await amm.connect(user).approve(this.address, amm.contract.balanceOf(addressOf(user)));
     return this.connect(user).exitAmmGivenAmountsOutAndEarlyRedeem(
       amm.address,
       pool.tempus.address,
@@ -232,7 +232,7 @@ export class TempusController extends ContractBase {
 
   async exitAmmGivenLpAndRedeem(
     pool:PoolTestFixture, 
-    user: SignerOrAddress, 
+    user: Addressable, 
     lpTokens:Numberish, 
     principals:Numberish, 
     yields:Numberish, 

--- a/tempus-sdk/tempus/TempusOTC.ts
+++ b/tempus-sdk/tempus/TempusOTC.ts
@@ -1,6 +1,6 @@
 import { Contract, Transaction } from "ethers";
 import { Numberish } from "../utils/DecimalUtils";
-import { ContractBase, SignerOrAddress, Signer } from "../utils/ContractBase";
+import { ContractBase, Addressable, Signer } from "../utils/ContractBase";
 import { ERC20 } from "../utils/ERC20";
 import { getContractAddress } from '@ethersproject/address';
 
@@ -58,7 +58,7 @@ export class TempusOTC extends ContractBase {
    * @param user The caller who is sending this approve
    * @param amount Amount of tokens to approve in contract decimals, eg 2.0 or "0.00001"
    */
-  async approve(token: ERC20, user:SignerOrAddress, amount:Numberish): Promise<void> {
+  async approve(token: ERC20, user:Addressable, amount:Numberish): Promise<void> {
     await token.approve(user, this.address, amount);
   }
   
@@ -66,9 +66,7 @@ export class TempusOTC extends ContractBase {
    * @dev Accept offer
    * @param user The caller who is accept offer (must be same as taker)
    */ 
-  async buy(
-    user:SignerOrAddress,
-  ): Promise<Transaction>{
+  async buy(user:Addressable): Promise<Transaction>{
     await this.approve(this.tokenToSell, user, this.sellAmount);
     
     return this.connect(user).buy();
@@ -78,9 +76,7 @@ export class TempusOTC extends ContractBase {
    * @dev Cancel offer
    * @param user The caller who is cancel offer (must be same user that create offer and contract owner)
    */ 
-  async cancel(
-    user:SignerOrAddress
-  ): Promise<Transaction>{
+  async cancel(user:Addressable): Promise<Transaction>{
     return this.connect(user).cancel();
   }
 }

--- a/tempus-sdk/tempus/TempusPool.ts
+++ b/tempus-sdk/tempus/TempusPool.ts
@@ -1,7 +1,7 @@
 import { BigNumber, BytesLike, Contract, Transaction } from "ethers";
 import { Decimal } from "../utils/Decimal";
 import { Numberish, toWei, parseDecimal, formatDecimal, MAX_UINT256 } from "../utils/DecimalUtils";
-import { ContractBase, Signer, SignerOrAddress, addressOf } from "../utils/ContractBase";
+import { ContractBase, Signer, Addressable, addressOf } from "../utils/ContractBase";
 import { ERC20 } from "../utils/ERC20";
 import { IERC20 } from "../utils/IERC20";
 import { PoolShare, ShareKind } from "./PoolShare";
@@ -369,14 +369,14 @@ export class TempusPool extends ContractBase {
     return this.yieldBearing.balanceOf(this.contract.address);
   }
 
-  async onDepositYieldBearing(user:SignerOrAddress, yieldBearingAmount:Numberish, recipient:SignerOrAddress): Promise<Transaction> {
+  async onDepositYieldBearing(user:Addressable, yieldBearingAmount:Numberish, recipient:Addressable): Promise<Transaction> {
     await this.yieldBearing.approve(user, this.contract.address, yieldBearingAmount);
     return this.connect(user).onDepositYieldBearing(
       this.yieldBearing.toBigNum(yieldBearingAmount), addressOf(recipient)
     );
   }
 
-  async onDepositBacking(user:SignerOrAddress, backingTokenAmount:Numberish, recipient:SignerOrAddress, ethValue: Numberish = 0): Promise<Transaction> {
+  async onDepositBacking(user:Addressable, backingTokenAmount:Numberish, recipient:Addressable, ethValue: Numberish = 0): Promise<Transaction> {
     return this.connect(user).onDepositBacking(
       this.asset.toBigNum(backingTokenAmount), addressOf(recipient), { value: toWei(ethValue)}
     );
@@ -390,8 +390,8 @@ export class TempusPool extends ContractBase {
    * @param from Address of which Tempus Shares should be burned
    * @param recipient Address to which redeemed Backing Tokens should be transferred
    */
-  async redeemToBacking(user:SignerOrAddress, principalAmount:Numberish, yieldAmount:Numberish, from: SignerOrAddress = user, recipient: SignerOrAddress = user): Promise<Transaction> {
-    return this.contract.connect(user).redeemToBacking(
+  async redeemToBacking(user:Addressable, principalAmount:Numberish, yieldAmount:Numberish, from: Addressable = user, recipient: Addressable = user): Promise<Transaction> {
+    return this.connect(user).redeemToBacking(
       addressOf(from), this.principalShare.toBigNum(principalAmount), this.yieldShare.toBigNum(yieldAmount), addressOf(recipient)
     );
   }
@@ -404,9 +404,9 @@ export class TempusPool extends ContractBase {
    * @param from Address of which Tempus Shares should be burned
    * @param recipient Address to which redeemed Yield Bearing Tokens should be transferred
    */
-  async redeem(user:SignerOrAddress, principalAmount:Numberish, yieldAmount:Numberish, from: SignerOrAddress = user, recipient: SignerOrAddress = user): Promise<Transaction> {
+  async redeem(user:Addressable, principalAmount:Numberish, yieldAmount:Numberish, from: Addressable = user, recipient: Addressable = user): Promise<Transaction> {
     try {
-      return this.contract.connect(user).redeem(
+      return this.connect(user).redeem(
         addressOf(from), this.principalShare.toBigNum(principalAmount), this.yieldShare.toBigNum(yieldAmount), addressOf(recipient)
       );
     } catch(e) {
@@ -574,10 +574,10 @@ export class TempusPool extends ContractBase {
    * Sets fees config for the pool. Caller must be owner
    */
   async setFeesConfig(
-    owner:SignerOrAddress,
+    owner:Addressable,
     feesConfig: TempusFeesConfig
   ): Promise<void> {
-    await this.contract.connect(owner).setFeesConfig({
+    await this.connect(owner).setFeesConfig({
       depositPercent:      this.yieldBearing.toBigNum(feesConfig.depositPercent),
       earlyRedeemPercent:  this.yieldBearing.toBigNum(feesConfig.earlyRedeemPercent),
       matureRedeemPercent: this.yieldBearing.toBigNum(feesConfig.matureRedeemPercent)
@@ -587,8 +587,8 @@ export class TempusPool extends ContractBase {
   /**
    * Transfers fees to the recipient. Caller must be owner.
    */
-  async transferFees(owner:SignerOrAddress, recipient:SignerOrAddress): Promise<void> {
-    await this.contract.connect(owner).transferFees(addressOf(recipient));
+  async transferFees(owner:Addressable, recipient:Addressable): Promise<void> {
+    await this.connect(owner).transferFees(addressOf(recipient));
   }
 
   async supportsInterface(interfaceId: string): Promise<Boolean> {

--- a/tempus-sdk/tempus/TempusToken.ts
+++ b/tempus-sdk/tempus/TempusToken.ts
@@ -1,5 +1,5 @@
 import { Numberish } from "../utils/DecimalUtils";
-import { SignerOrAddress, addressOf } from "../utils/ContractBase";
+import { Addressable, addressOf } from "../utils/ContractBase";
 import { ERC20 } from "../utils/ERC20";
 import { Transaction } from "@ethersproject/transactions";
 
@@ -16,7 +16,7 @@ export class TempusToken extends ERC20 {
    * @param sender Account that is issuing the burn.
    * @param amount Number of tokens to burn
    */
-  async burn(sender:SignerOrAddress, amount:Numberish): Promise<void> {
+  async burn(sender:Addressable, amount:Numberish): Promise<void> {
     await this.connect(sender).burn(this.toBigNum(amount));
   }
 
@@ -26,7 +26,7 @@ export class TempusToken extends ERC20 {
    * @param account Account to which we issue tokens
    * @param amount Number of tokens to mint
    */
-  async mint(sender:SignerOrAddress, account:SignerOrAddress, amount:Numberish): Promise<Transaction> {
+  async mint(sender:Addressable, account:Addressable, amount:Numberish): Promise<Transaction> {
     return this.connect(sender).mint(addressOf(account), this.toBigNum(amount));
   }
 

--- a/tempus-sdk/utils/Comptroller.ts
+++ b/tempus-sdk/utils/Comptroller.ts
@@ -1,7 +1,7 @@
 import { Contract, BigNumber } from "ethers";
 import { Decimal } from "./Decimal";
 import { formatDecimal, Numberish, parseDecimal } from "./DecimalUtils";
-import { addressOf, ContractBase, SignerOrAddress } from "./ContractBase";
+import { addressOf, ContractBase, Addressable } from "./ContractBase";
 import { ERC20 } from "./ERC20";
 import { TokenInfo } from "../../test/pool-utils/TokenInfo";
 
@@ -40,14 +40,14 @@ export class Comptroller extends ContractBase {
   /**
    * @return Current Asset balance of the user as a decimal, eg. 1.0
    */
-  async assetBalance(user:SignerOrAddress): Promise<Decimal> {
+  async assetBalance(user:Addressable): Promise<Decimal> {
     return await this.asset.balanceOf(user);
   }
 
   /**
    * @return Yield Token balance of the user as a decimal, eg. 2.0
    */
-  async yieldBalance(user:SignerOrAddress): Promise<Decimal> {
+  async yieldBalance(user:Addressable): Promise<Decimal> {
     return await this.yieldToken.balanceOf(user);
   }
 
@@ -62,7 +62,7 @@ export class Comptroller extends ContractBase {
   /**
    * Sets the pool Exchange Rate, converting it to exchange rate decimal which has variable decimal precision
    */
-  async setExchangeRate(exchangeRate:Numberish, owner:SignerOrAddress = null): Promise<void> {
+  async setExchangeRate(exchangeRate:Numberish, owner:Addressable = null): Promise<void> {
     if (owner !== null) {
       const prevExchangeRate = await this.exchangeRate();
       const difference = (Number(exchangeRate) / Number(prevExchangeRate)) - 1;
@@ -79,8 +79,8 @@ export class Comptroller extends ContractBase {
    * @notice Add assets to be included in account liquidity calculation
    * @return Success indicator for whether each corresponding market was entered
    */
-  async enterMarkets(user:SignerOrAddress): Promise<boolean> {
-    const results:BigNumber[] = await this.contract.connect(user).enterMarkets([this.yieldToken.address]);
+  async enterMarkets(user:Addressable): Promise<boolean> {
+    const results:BigNumber[] = await this.connect(user).enterMarkets([this.yieldToken.address]);
     return results[0] == BigNumber.from("0"); // no error
   }
 
@@ -91,8 +91,8 @@ export class Comptroller extends ContractBase {
    * @param cTokenAddress The address of the asset to be removed
    * @return Whether or not the account successfully exited the market
    */
-  async exitMarket(user:SignerOrAddress): Promise<boolean> {
-    const result:BigNumber = await this.contract.connect(user).exitMarket(this.yieldToken.address);
+  async exitMarket(user:Addressable): Promise<boolean> {
+    const result:BigNumber = await this.connect(user).exitMarket(this.yieldToken.address);
     return result == BigNumber.from("0"); // no error
   }
 
@@ -100,7 +100,7 @@ export class Comptroller extends ContractBase {
    * @dev MOCK ONLY
    * @return True if user is particiapnt in cToken market
    */
-  async isParticipant(user:SignerOrAddress): Promise<boolean> {
+  async isParticipant(user:Addressable): Promise<boolean> {
     return await this.contract.isParticipant(this.yieldToken.address, addressOf(user));
   }
 
@@ -109,15 +109,15 @@ export class Comptroller extends ContractBase {
    * @param user User to check
    * @param mintAmount How much he wants to mint
    */
-  async mintAllowed(user:SignerOrAddress, mintAmount:Numberish): Promise<boolean> {
+  async mintAllowed(user:Addressable, mintAmount:Numberish): Promise<boolean> {
     return await this.contract.mintAllowed(this.yieldToken.address, addressOf(user), this.asset.toBigNum(mintAmount)) == 0;
   }
 
   /**
    * Calls CErc20 mint() on the CToken, which means CToken must be CErc20 (like cDAI)
    */
-  async mint(user:SignerOrAddress, amount:Numberish) {
+  async mint(user:Addressable, amount:Numberish) {
     await this.asset.approve(user, this.yieldToken.address, amount);
-    await this.yieldToken.contract.connect(user).mint(this.asset.toBigNum(amount));
+    await this.yieldToken.connect(user).mint(this.asset.toBigNum(amount));
   }
 }

--- a/tempus-sdk/utils/ContractBase.ts
+++ b/tempus-sdk/utils/ContractBase.ts
@@ -2,12 +2,16 @@ import { ethers } from "hardhat";
 import { Contract } from "ethers";
 import { DecimalConvertible } from "./DecimalConvertible";
 import * as signers from "@nomiclabs/hardhat-ethers/dist/src/signers";
-import * as abstractSigner from "@ethersproject/abstract-signer/src.ts";
+import * as signer from "@ethersproject/abstract-signer/src.ts";
 
-export type AbstractSigner = abstractSigner.Signer;
+/** Alias for ethers Signer with Address */
 export type Signer = signers.SignerWithAddress;
-export type SignerOrAddress = Signer|string;
-export type Addressable = SignerOrAddress|ContractBase|Contract;
+
+/** Alias for accepting abstract signer or an address */
+export type SignerOrAddress = signer.Signer|Signer|string;
+
+/** Alias for all types that can provide an address to the contracts. @see addressOf(addressable) */
+export type Addressable = Signer|string|ContractBase|Contract;
 
 /** @return Address field from signer or address string */
 export function addressOf(addressable: Addressable): string {
@@ -20,7 +24,7 @@ export function addressOf(addressable: Addressable): string {
 }
 
 /** @return Signer or an address string */
-export function signerOf(addressable: Addressable): SignerOrAddress {
+export function signerOf(addressable: Addressable): signer.Signer|Signer|string {
   if (typeof(addressable) === "string")
     return addressable;
   if (addressable instanceof ContractBase || addressable instanceof Contract)
@@ -97,8 +101,9 @@ export abstract class ContractBase extends DecimalConvertible
    * @param contractAddress Address of the contract
    * @param signer Signer to attach with, can be ethers.VoidSigner or SignerWithAddress
    */
-  static async attachContractWithSigner(contractName:string, contractAddress:string, signer:AbstractSigner): Promise<Contract> {
-    const factory = await ethers.getContractFactory(contractName, signer);
+  static async attachContractWithSigner(contractName:string, contractAddress:string, signer:Addressable): Promise<Contract> {
+    const signerOrProvider = signerOf(signer);
+    const factory = await ethers.getContractFactory(contractName, signerOrProvider);
     return factory.attach(contractAddress);
   }
 }

--- a/tempus-sdk/utils/ERC20.ts
+++ b/tempus-sdk/utils/ERC20.ts
@@ -1,7 +1,7 @@
 import { Contract, Transaction } from "ethers";
 import { Decimal } from "./Decimal";
 import { Numberish } from "./DecimalUtils";
-import { ContractBase, Signer, AbstractSigner, Addressable, addressOf } from "./ContractBase";
+import { ContractBase, Signer, Addressable, addressOf } from "./ContractBase";
 import { IERC20 } from "./IERC20";
 
 /**
@@ -61,7 +61,7 @@ export class ERC20 extends ContractBase implements IERC20 {
    * @param contractAddress Address of the contract
    * @param signer Signer to attach with, can be ethers.VoidSigner or SignerWithAddress
    */
-  static async attachWithSigner(contractName:string, contractAddress:string, signer:AbstractSigner): Promise<ERC20> {
+  static async attachWithSigner(contractName:string, contractAddress:string, signer:Addressable): Promise<ERC20> {
     if (!signer) {
       throw new Error("attachWithSigner: `signer` must not be null");
     }

--- a/test/pool-utils/PoolTestFixture.ts
+++ b/test/pool-utils/PoolTestFixture.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { Transaction } from "ethers";
 import { deployments, ethers } from "hardhat";
-import { ContractBase, Signer, SignerOrAddress } from "@tempus-sdk/utils/ContractBase";
+import { ContractBase, Signer, Addressable } from "@tempus-sdk/utils/ContractBase";
 import { TempusPool, PoolType, TempusSharesNames, generateTempusSharesNames } from "@tempus-sdk/tempus/TempusPool";
 import { blockTimestamp, setEvmTime, setNextBlockTimestamp } from "@tempus-sdk/utils/Utils";
 import { ERC20 } from "@tempus-sdk/utils/ERC20";
@@ -210,14 +210,14 @@ export abstract class PoolTestFixture {
   /**
    * Deposit YieldBearingTokens into TempusPool
    */
-  async depositYBT(user:Signer, yieldBearingAmount:Numberish, recipient:SignerOrAddress = user): Promise<Transaction> {
+  async depositYBT(user:Signer, yieldBearingAmount:Numberish, recipient:Addressable = user): Promise<Transaction> {
     return this.tempus.controller.depositYieldBearing(user, this.tempus, yieldBearingAmount, recipient);
   }
 
   /**
    * Deposit BackingTokens into TempusPool
    */
-  async depositBT(user:Signer, backingTokenAmount:Numberish, recipient:SignerOrAddress = user, ethValue: Numberish = undefined): Promise<Transaction> {
+  async depositBT(user:Signer, backingTokenAmount:Numberish, recipient:Addressable = user, ethValue: Numberish = undefined): Promise<Transaction> {
     const ethToTransfer = this.acceptsEther ? ((ethValue == undefined) ? backingTokenAmount : ethValue) : (ethValue || 0);
     return this.tempus.controller.depositBacking(user, this.tempus, backingTokenAmount, recipient, ethToTransfer);
   }
@@ -225,14 +225,14 @@ export abstract class PoolTestFixture {
   /**
    * Redeems TempusShares to YieldBearingTokens
    */
-  async redeemToYBT(user:Signer, principalAmount:Numberish, yieldAmount:Numberish, recipient:SignerOrAddress = user): Promise<Transaction> {
+  async redeemToYBT(user:Signer, principalAmount:Numberish, yieldAmount:Numberish, recipient:Addressable = user): Promise<Transaction> {
     return this.tempus.controller.redeemToYieldBearing(user, this.tempus, principalAmount, yieldAmount, recipient);
   }
 
   /**
    * Redeems TempusShares to BackingTokens
    */
-  async redeemToBT(user:Signer, principalAmount:Numberish, yieldAmount:Numberish, recipient:SignerOrAddress = user): Promise<Transaction> {
+  async redeemToBT(user:Signer, principalAmount:Numberish, yieldAmount:Numberish, recipient:Addressable = user): Promise<Transaction> {
     return this.tempus.controller.redeemToBacking(user, this.tempus, principalAmount, yieldAmount, recipient);
   }
 
@@ -242,7 +242,7 @@ export abstract class PoolTestFixture {
    * @example (await pool.expectDepositYBT(user, 100)).to.equal('success');
    * @returns RevertMessage assertion, or 'success' assertion
    */
-  async expectDepositYBT(user:Signer, yieldBearingAmount:Numberish, recipient:SignerOrAddress = user): Promise<Chai.Assertion> {
+  async expectDepositYBT(user:Signer, yieldBearingAmount:Numberish, recipient:Addressable = user): Promise<Chai.Assertion> {
     try {
       await this.depositYBT(user, yieldBearingAmount, recipient);
       return expect('success');
@@ -257,7 +257,7 @@ export abstract class PoolTestFixture {
    * @example (await pool.expectDepositBT(user, 100)).to.equal('success');
    * @returns RevertMessage assertion, or 'success' assertion
    */
-  async expectDepositBT(user:Signer, backingTokenAmount:Numberish, recipient:SignerOrAddress = user, ethValue: Numberish = undefined): Promise<Chai.Assertion> {
+  async expectDepositBT(user:Signer, backingTokenAmount:Numberish, recipient:Addressable = user, ethValue: Numberish = undefined): Promise<Chai.Assertion> {
     try {
       await this.depositBT(user, backingTokenAmount, recipient, ethValue);
       return expect('success');
@@ -272,7 +272,7 @@ export abstract class PoolTestFixture {
    * @example (await pool.expectRedeemYBT(user, 100, 100)).to.equal('success');
    * @returns RevertMessage assertion, or 'success' assertion
    */
-  async expectRedeemYBT(user:Signer, principalShares:Numberish, yieldShares:Numberish, recipient:SignerOrAddress = user): Promise<Chai.Assertion> {
+  async expectRedeemYBT(user:Signer, principalShares:Numberish, yieldShares:Numberish, recipient:Addressable = user): Promise<Chai.Assertion> {
     try {
       await this.redeemToYBT(user, principalShares, yieldShares, recipient);
       return expect('success');
@@ -287,7 +287,7 @@ export abstract class PoolTestFixture {
    * @example (await pool.expectRedeemYBT(user, 100, 100)).to.equal('success');
    * @returns RevertMessage assertion, or 'success' assertion
    */
-  async expectRedeemBT(user:Signer, principalShares:Numberish, yieldShares:Numberish, recipient:SignerOrAddress = user): Promise<Chai.Assertion> {
+  async expectRedeemBT(user:Signer, principalShares:Numberish, yieldShares:Numberish, recipient:Addressable = user): Promise<Chai.Assertion> {
     try {
       await this.redeemToBT(user, principalShares, yieldShares, recipient);
       return expect('success');

--- a/test/protocols/Aave.ts
+++ b/test/protocols/Aave.ts
@@ -1,7 +1,7 @@
 import { Contract } from "ethers";
 import { Decimal } from "@tempus-sdk/utils/Decimal";
 import { Numberish, toRay, fromRay, parseDecimal } from "@tempus-sdk/utils/DecimalUtils";
-import { ContractBase, SignerOrAddress, addressOf } from "@tempus-sdk/utils/ContractBase";
+import { ContractBase, Addressable, addressOf } from "@tempus-sdk/utils/ContractBase";
 import { ERC20 } from "@tempus-sdk/utils/ERC20";
 import { TokenInfo } from "../pool-utils/TokenInfo";
 
@@ -34,14 +34,14 @@ export class Aave extends ContractBase {
   /**
    * @return Current Asset balance of the user as a decimal, eg. 1.0
    */
-  async assetBalance(user:SignerOrAddress): Promise<Decimal> {
+  async assetBalance(user:Addressable): Promise<Decimal> {
     return await this.asset.balanceOf(user);
   }
 
   /**
    * @return Yield Token balance of the user as a decimal, eg. 2.0
    */
-  async yieldBalance(user:SignerOrAddress): Promise<Decimal> {
+  async yieldBalance(user:Addressable): Promise<Decimal> {
     return this.toDecimal(await this.contract.getDeposit(addressOf(user)));
   }
 
@@ -56,7 +56,7 @@ export class Aave extends ContractBase {
   /**
    * Sets the AAVE pool's MOCK liquidity index in RAY
    */
-  async setLiquidityIndex(liquidityIndex:Numberish, owner:SignerOrAddress = null): Promise<void> {
+  async setLiquidityIndex(liquidityIndex:Numberish, owner:Addressable = null): Promise<void> {
     if (owner !== null) {
       const prevLiquidityIndex = await this.liquidityIndex();
       const difference = (Number(liquidityIndex) / Number(prevLiquidityIndex)) - 1;
@@ -74,8 +74,8 @@ export class Aave extends ContractBase {
    * @param user User who wants to deposit ETH into AAVE Pool
    * @param amount # of ETH to deposit, eg: 1.0
    */
-  async deposit(user:SignerOrAddress, amount:Numberish): Promise<void> {
+  async deposit(user:Addressable, amount:Numberish): Promise<void> {
     await this.asset.approve(user, this.address, amount);
-    await this.contract.connect(user).deposit(this.asset.address, this.toBigNum(amount), addressOf(user), 0);
+    await this.connect(user).deposit(this.asset.address, this.toBigNum(amount), addressOf(user), 0);
   }
 }

--- a/test/protocols/LidoContract.ts
+++ b/test/protocols/LidoContract.ts
@@ -2,7 +2,7 @@ import { ethers } from "hardhat";
 import { BigNumber, Contract } from "ethers";
 import { Decimal } from "@tempus-sdk/utils/Decimal";
 import { Numberish, parseDecimal } from "@tempus-sdk/utils/DecimalUtils";
-import { SignerOrAddress, Signer, addressOf } from "@tempus-sdk/utils/ContractBase";
+import { Addressable, Signer, addressOf } from "@tempus-sdk/utils/ContractBase";
 import { ERC20 } from "@tempus-sdk/utils/ERC20";
 import { ERC20Ether } from "@tempus-sdk/utils/ERC20Ether";
 
@@ -17,7 +17,7 @@ export abstract class LidoContract extends ERC20 {
   }
 
   /** @return stETH balance of an user */
-  async sharesOf(user:SignerOrAddress): Promise<Decimal> {
+  async sharesOf(user:Addressable): Promise<Decimal> {
     return this.toDecimal(await this.contract.sharesOf(addressOf(user)));
   }
 
@@ -60,7 +60,7 @@ export abstract class LidoContract extends ERC20 {
    */
   abstract setInterestRate(interestRate:Numberish): Promise<void>;
 
-  async submit(signer:SignerOrAddress, amount:Numberish): Promise<Numberish> {
+  async submit(signer:Addressable, amount:Numberish): Promise<Numberish> {
     const val = this.toBigNum(amount); // payable call, set value:
     return await this.connect(signer).submit(addressOf(signer), {value: val})
   }

--- a/test/protocols/RariFundManager.ts
+++ b/test/protocols/RariFundManager.ts
@@ -1,6 +1,6 @@
 import { Contract } from "ethers";
 import { Numberish, parseDecimal } from "@tempus-sdk/utils/DecimalUtils";
-import { ContractBase, SignerOrAddress } from "@tempus-sdk/utils/ContractBase";
+import { ContractBase, Addressable } from "@tempus-sdk/utils/ContractBase";
 import { ERC20 } from "@tempus-sdk/utils/ERC20";
 import { TokenInfo } from "test/pool-utils/TokenInfo";
 
@@ -36,8 +36,8 @@ export class RariFundManager extends ContractBase {
     await this.contract.setInterestRate(parseDecimal(interest.toString(), 18));
   }
 
-  async deposit(user:SignerOrAddress, amount:Numberish): Promise<void> {
+  async deposit(user:Addressable, amount:Numberish): Promise<void> {
     await this.asset.approve(user, this.address, amount);
-    await this.contract.connect(user).deposit((await this.asset.symbol()), this.asset.toBigNum(amount));
+    await this.connect(user).deposit((await this.asset.symbol()), this.asset.toBigNum(amount));
   }
 }

--- a/test/protocols/YearnVault.ts
+++ b/test/protocols/YearnVault.ts
@@ -1,6 +1,6 @@
 import { Contract } from "ethers";
 import { Numberish, formatDecimal, parseDecimal } from "@tempus-sdk/utils/DecimalUtils";
-import { ContractBase, SignerOrAddress } from "@tempus-sdk/utils/ContractBase";
+import { ContractBase, Addressable } from "@tempus-sdk/utils/ContractBase";
 import { ERC20 } from "@tempus-sdk/utils/ERC20";
 import { TokenInfo } from "test/pool-utils/TokenInfo";
 
@@ -36,7 +36,7 @@ export class YearnVault extends ContractBase {
   /**
    * Sets the pool price per share
    */
-  async setPricePerShare(pricePerShare:Numberish, owner:SignerOrAddress = null): Promise<void> {
+  async setPricePerShare(pricePerShare:Numberish, owner:Addressable = null): Promise<void> {
     if (owner !== null) {
       const prevExchangeRate = await this.pricePerShare();
       const difference = (Number(pricePerShare) / Number(prevExchangeRate)) - 1;
@@ -49,12 +49,12 @@ export class YearnVault extends ContractBase {
     await this.contract.setPricePerShare(parseDecimal(pricePerShare.toString(), this.yieldToken.decimals));
   }
 
-  async deposit(user:SignerOrAddress, amount:Numberish): Promise<void> {
+  async deposit(user:Addressable, amount:Numberish): Promise<void> {
     await this.asset.approve(user, this.address, amount);
-    await this.contract.connect(user).deposit(this.asset.toBigNum(amount));
+    await this.connect(user).deposit(this.asset.toBigNum(amount));
   }
 
-  async withdraw(user:SignerOrAddress, maxShares:Numberish, recipient: SignerOrAddress): Promise<void> {
-    await this.contract.connect(user).deposit(this.yieldToken.toBigNum(maxShares), recipient);
+  async withdraw(user:Addressable, maxShares:Numberish, recipient: Addressable): Promise<void> {
+    await this.connect(user).deposit(this.yieldToken.toBigNum(maxShares), recipient);
   }
 }


### PR DESCRIPTION
... Reducing usage and exposure of more complicated underlying types.

And fixed a few places where `this.contract.connect(user)` was used instead of `this.connect(user)`.

In total this should make our wrapper interfaces easier to understand, since "Addressable" is a simple concept. Added basic docs to the type aliases as well.